### PR TITLE
Enable PEP 484: type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
           - --exit-zero
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus, --keep-runtime-typing]
@@ -143,7 +143,7 @@ repos:
         exclude: ^mailgun/examples/
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.390
+    rev: v1.1.391
     hooks:
     - id: pyright
 
@@ -157,7 +157,7 @@ repos:
         additional_dependencies: [".[toml]"]
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.28.3
+    rev: v1.28.4
     hooks:
       - id: typos
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,21 +131,21 @@ repos:
       hooks:
       -   id: refurb
           language_version: python3.12
-#
-#  - repo: https://github.com/pre-commit/mirrors-mypy
-#    rev: v1.13.0
-#    hooks:
-#    -   id: mypy
-#        args:
-#          [
-#            --config-file=./pyproject.toml,
-#          ]
-#        exclude: ^samples/
-#
-#  - repo: https://github.com/RobertCraigie/pyright-python
-#    rev: v1.1.390
-#    hooks:
-#    - id: pyright
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.13.0
+    hooks:
+    -   id: mypy
+        args:
+          [
+            --config-file=./pyproject.toml,
+          ]
+        exclude: ^mailgun/examples/
+
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.390
+    hooks:
+    - id: pyright
 
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.0

--- a/environment-dev.yaml
+++ b/environment-dev.yaml
@@ -21,6 +21,7 @@ dependencies:
   - flake8
   - isort
   - make
+  - conda-forge::monkeytype
   - mypy
   - pandas-stubs
   - pep8-naming
@@ -44,7 +45,6 @@ dependencies:
       - autoflake8
       - bandit
       - docconvert
-      - monkeytype
       - pyment >=0.3.3
       - pytype
       - pyupgrade

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -6,7 +6,7 @@ from typing import Any
 from typing import Callable
 from urllib.parse import urljoin
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 from mailgun.handlers.default_handler import handle_default
 from mailgun.handlers.domains_handler import handle_domainlist
@@ -28,6 +28,7 @@ from mailgun.handlers.templates_handler import handle_templates
 
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from collections.abc import Sequence
 
     from requests.models import Response  # type: ignore[import-untyped]
@@ -188,16 +189,16 @@ class Endpoint:
         url: dict[str, str],
         headers: dict[str, str],
         data: dict | None = None,
-        filters=None,
+        filters: Mapping[str, str | Any] | None = None,
         timeout: int = 60,
-        files=None,
+        files: dict | None = None,
         domain: str | None = None,
         **kwargs: Any,
     ) -> Response | Any:
         """Build URL and make a request.
 
         :param auth: auth data
-        :type auth: tuple[str, str]
+        :type auth: tuple[str, str] | None
         :param method: request method
         :type method: str
         :param url: incoming url (base+keys)
@@ -205,20 +206,20 @@ class Endpoint:
         :param headers: incoming headers
         :type headers: dict[str, str]
         :param data: incoming post/put data
-        :type data: dict
+        :type data: dict | None
         :param filters: incoming params
-        :type filters: dict
+        :type filters: dict | None
         :param timeout: requested timeout (60-default)
         :type timeout: int
         :param files: incoming files
-        :type files: dict
+        :type files: dict | None
         :param domain: incoming domain
-        :type domain: str
+        :type domain: str | None
         :param kwargs: kwargs
         :type kwargs: Any
         :return: server response from API
         """
-        url = self.build_url(url, domain=domain, method=method, **kwargs)
+        url: str = self.build_url(url, domain=domain, method=method, **kwargs)
         req_method = getattr(requests, method)
 
         try:
@@ -247,7 +248,7 @@ class Endpoint:
         domain: dict | None = None,
         method: str | None = None,
         **kwargs: Any,
-    ):
+    ) -> str:
         """Build final request url using predefined handlers.
 
         Note: Some urls are being built in Config class, as they can't be generated dynamically.
@@ -258,18 +259,25 @@ class Endpoint:
         :param method: requested method
         :type method: str
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: built URL
         """
         return HANDLERS[url["keys"][0]](url, domain, method, **kwargs)
 
-    def get(self, filters=None, domain=None, **kwargs):
+    def get(
+        self,
+        filters: Mapping[str, str | Any] | None = None,
+        domain: str | None = None,
+        **kwargs: Any,
+    ) -> Response:
         """GET method for API calls.
 
         :param filters: incoming params
-        :type filters: dict
+        :type filters: Mapping[str, str | Any] | None
         :param domain: incoming domain
-        :type domain: str
+        :type domain: str | None
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call GET request
         """
         return self.api_call(
@@ -284,26 +292,27 @@ class Endpoint:
 
     def create(
         self,
-        data=None,
-        filters=None,
-        domain=None,
-        headers=None,
+        data: dict | None = None,
+        filters: Mapping[str, str | Any] | None = None,
+        domain: str | None = None,
+        headers: dict[str, str] | None = None,
         files=None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> Response:
         """POST method for API calls.
 
         :param data: incoming post data
-        :type data: dict
+        :type data: dict | None
         :param filters: incoming params
         :type filters: dict
         :param domain: incoming domain
         :type domain: str
         :param headers: incoming headers
-        :type headers: dict
+        :type headers: dict[str, str]
         :param files: incoming files
         :type files: file
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call POST request
         """
         if "Content-type" in self.headers:
@@ -328,14 +337,20 @@ class Endpoint:
             **kwargs,
         )
 
-    def put(self, data=None, filters=None, **kwargs):
+    def put(
+        self,
+        data: dict | None = None,
+        filters: Mapping[str, str | Any] | None = None,
+        **kwargs: Any,
+    ) -> Response:
         """PUT method for API calls.
 
         :param data: incoming data
-        :type data: dict
+        :type data: dict | None
         :param filters: incoming params
         :type filters: dict
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call POST request
         """
         return self.api_call(
@@ -348,14 +363,20 @@ class Endpoint:
             **kwargs,
         )
 
-    def patch(self, data=None, filters=None, **kwargs):
+    def patch(
+        self,
+        data: dict | None = None,
+        filters: Mapping[str, str | Any] | None = None,
+        **kwargs: Any,
+    ) -> Response:
         """PATCH method for API calls.
 
         :param data: incoming data
-        :type data: dict
+        :type data: dict | None
         :param filters: incoming params
         :type filters: dict
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call PATCH request
         """
         return self.api_call(
@@ -368,14 +389,20 @@ class Endpoint:
             **kwargs,
         )
 
-    def update(self, data, filters=None, **kwargs):
+    def update(
+        self,
+        data: dict | None,
+        filters: Mapping[str, str | Any] | None = None,
+        **kwargs: Any,
+    ) -> Response:
         """PUT method for API calls.
 
         :param data: incoming data
-        :type data: dict
+        :type data: dict | None
         :param filters: incoming params
         :type filters: dict
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call PUT request
         """
         if self.headers["Content-type"] == "application/json":
@@ -390,12 +417,13 @@ class Endpoint:
             **kwargs,
         )
 
-    def delete(self, domain=None, **kwargs):
+    def delete(self, domain: str | None = None, **kwargs: Any) -> Response:
         """DELETE method for API calls.
 
         :param domain: incoming domain
         :type domain: str
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: api_call DELETE request
         """
         return self.api_call(
@@ -411,7 +439,7 @@ class Endpoint:
 class Client:
     """Client class."""
 
-    def __init__(self, auth=None, **kwargs):
+    def __init__(self, auth: tuple[str, str] | None = None, **kwargs: Any) -> None:
         """Initialize a new Client instance for API interaction.
 
         This method sets up API authentication and configuration. The `auth` parameter
@@ -427,7 +455,7 @@ class Client:
         api_url = kwargs.get("api_url")
         self.config = Config(version=version, api_url=api_url)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         """Get named attribute of an object, split it and execute.
 
         :param name: attribute name (Example: client.domains_ips. names: ["domains", "ips"])

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -29,7 +29,6 @@ from mailgun.handlers.templates_handler import handle_templates
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from collections.abc import Sequence
 
     from requests.models import Response
 
@@ -85,7 +84,7 @@ class Config:
         self.ex_handler: bool = True
         self.api_url = api_url or self.DEFAULT_API_URL
 
-    def __getitem__(self, key: str) -> tuple[dict[str, Sequence[str]], dict[str, str]]:
+    def __getitem__(self, key: str) -> tuple[dict[str, Any], dict[str, str]]:
         """Parse incoming split attr name, check it and prepare endpoint url.
 
         Most urls generated here can't be generated dynamically as we are doing this
@@ -99,13 +98,10 @@ class Config:
         base_url: str = urljoin(self.api_url, self.version + "/")
         headers = {"User-agent": self.user_agent}
         modified = False
-        endpoint_url: dict[str, Sequence[str]]
+        url: dict[str, Any]
         # Domains section
         if key.lower() == "domainlist":
-            endpoint_url = {
-                "base": base_url,
-                "keys": ["domainlist"],
-            }
+            url = {"base": base_url, "keys": ["domainlist"]}
             modified = True
         if "domains" in key.lower():
             split = [key.lower()]
@@ -119,45 +115,36 @@ class Config:
             elif "webprefix" in split:
                 final_keys = ["web_prefix"]
 
-            endpoint_url = {
+            url = {
                 "base": urljoin(self.api_url, self.version + "/domains/"),
                 "keys": final_keys,
             }
             modified = True
         # Messages section
         if key.lower() == "messages":
-            endpoint_url = {
-                "base": base_url,
-                "keys": ["messages"],
-            }
+            url = {"base": base_url, "keys": ["messages"]}
         if key.lower() == "mimemessage":
-            endpoint_url = {
-                "base": base_url,
-                "keys": ["messages.mime"],
-            }
+            url = {"base": base_url, "keys": ["messages.mime"]}
             modified = True
         if key.lower() == "resendmessage":
-            endpoint_url = {"keys": ["resendmessage"]}
+            url = {"keys": ["resendmessage"]}
             modified = True
 
         # IPpools section
         if key.lower() == "ippools":
-            endpoint_url = {
-                "base": base_url,
-                "keys": ["ip_pools"],
-            }
+            url = {"base": base_url, "keys": ["ip_pools"]}
             modified = True
         # Email Validation section
         if "addressvalidate" in key.lower():
-            endpoint_url = {
+            url = {
                 "base": urljoin(self.api_url, "v4" + "/address/validate"),
                 "keys": key.split("_"),
             }
             modified = True
 
         if not modified:
-            endpoint_url = {"base": base_url, "keys": key.split("_")}
-        return endpoint_url, headers
+            url = {"base": base_url, "keys": key.split("_")}
+        return url, headers
 
 
 class Endpoint:
@@ -165,14 +152,14 @@ class Endpoint:
 
     def __init__(
         self,
-        url: dict[str, str],
+        url: dict[str, Any],
         headers: dict[str, str],
         auth: tuple[str, str] | None,
     ):
         """Initialize a new Endpoint instance.
 
         :param url: URL dict with pairs {"base": "keys"}
-        :type url: dict[str, str]
+        :type url: dict[str, Any]
         :param headers: Headers dict
         :type headers: dict[str, str]
         :param auth: requests auth tuple
@@ -186,7 +173,7 @@ class Endpoint:
         self,
         auth: tuple[str, str] | None,
         method: str,
-        url: dict[str, str],
+        url: dict[str, Any],
         headers: dict[str, str],
         data: Any | None = None,
         filters: Mapping[str, str | Any] | None = None,
@@ -202,7 +189,7 @@ class Endpoint:
         :param method: request method
         :type method: str
         :param url: incoming url (base+keys)
-        :type url: dict[str, str]
+        :type url: dict[str, Any]
         :param headers: incoming headers
         :type headers: dict[str, str]
         :param data: incoming post/put data
@@ -244,7 +231,7 @@ class Endpoint:
 
     @staticmethod
     def build_url(
-        url: dict[str, str],
+        url: dict[str, Any],
         domain: str | None = None,
         method: str | None = None,
         **kwargs: Any,
@@ -253,7 +240,7 @@ class Endpoint:
 
         Note: Some urls are being built in Config class, as they can't be generated dynamically.
         :param url: incoming url (base+keys)
-        :type url: dict
+        :type url: dict[str, Any]
         :param domain: incoming domain
         :type domain: str
         :param method: requested method

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -1,4 +1,9 @@
+from __future__ import annotations
+
 import json
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
 from urllib.parse import urljoin
 
 import requests
@@ -22,7 +27,13 @@ from mailgun.handlers.tags_handler import handle_tags
 from mailgun.handlers.templates_handler import handle_templates
 
 
-HANDLERS = {
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from requests.models import Response  # type: ignore[import-untyped]
+
+
+HANDLERS: dict[str, Callable] = {
     "resendmessage": handle_resend_message,
     "domains": handle_domains,
     "domainlist": handle_domainlist,
@@ -51,29 +62,29 @@ HANDLERS = {
 class Config:
     """Config class. Configure client with basic (urls, version, headers)."""
 
-    DEFAULT_API_URL = "https://api.mailgun.net/"
-    API_REF = "https://documentation.mailgun.com/en/latest/api_reference.html"
-    version = "v3"
-    user_agent = "mailgun-api-python/"
+    DEFAULT_API_URL: str = "https://api.mailgun.net/"
+    API_REF: str = "https://documentation.mailgun.com/en/latest/api_reference.html"
+    version: str = "v3"
+    user_agent: str = "mailgun-api-python/"
 
-    def __init__(self, version=None, api_url=None):
+    def __init__(self, version: str | None = None, api_url: str | None = None) -> None:
         """Initialize a new Config instance with specified or default API settings.
 
         This initializer sets the API version and base URL. If no version or URL
         is provided, it defaults to the predefined class values.
 
         :param version: API version (default: v3)
-        :type version: str
+        :type version: str | None
         :param api_url: API base url
-        :type api_url: str
+        :type api_url: str | None
         """
         if version is not None:
             self.version = version
 
-        self.ex_handler = True
+        self.ex_handler: bool = True
         self.api_url = api_url or self.DEFAULT_API_URL
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> tuple[dict[str, Sequence[str]], dict[str, str]]:
         """Parse incoming split attr name, check it and prepare endpoint url.
 
         Most urls generated here can't be generated dynamically as we are doing this
@@ -151,15 +162,20 @@ class Config:
 class Endpoint:
     """Generate request and return response."""
 
-    def __init__(self, url, headers, auth):
+    def __init__(
+        self,
+        url: dict[str, str],
+        headers: dict[str, str],
+        auth: tuple[str, str] | None,
+    ):
         """Initialize a new Endpoint instance.
 
         :param url: URL dict with pairs {"base": "keys"}
-        :type url: dict
+        :type url: dict[str, str]
         :param headers: Headers dict
-        :type headers: dict
+        :type headers: dict[str, str]
         :param auth: requests auth tuple
-        :type auth: tuple
+        :type auth: tuple[str, str] | None
         """
         self._url = url
         self.headers = headers
@@ -167,27 +183,27 @@ class Endpoint:
 
     def api_call(
         self,
-        auth,
-        method,
-        url,
-        headers,
-        data=None,
+        auth: tuple[str, str] | None,
+        method: str,
+        url: dict[str, str],
+        headers: dict[str, str],
+        data: dict | None = None,
         filters=None,
-        timeout=60,
+        timeout: int = 60,
         files=None,
-        domain=None,
-        **kwargs,
-    ):
+        domain: str | None = None,
+        **kwargs: Any,
+    ) -> Response | Any:
         """Build URL and make a request.
 
         :param auth: auth data
-        :type auth: tuple
+        :type auth: tuple[str, str]
         :param method: request method
         :type method: str
         :param url: incoming url (base+keys)
-        :type url: dict
+        :type url: dict[str, str]
         :param headers: incoming headers
-        :type headers: dict
+        :type headers: dict[str, str]
         :param data: incoming post/put data
         :type data: dict
         :param filters: incoming params
@@ -199,6 +215,7 @@ class Endpoint:
         :param domain: incoming domain
         :type domain: str
         :param kwargs: kwargs
+        :type kwargs: Any
         :return: server response from API
         """
         url = self.build_url(url, domain=domain, method=method, **kwargs)
@@ -225,7 +242,12 @@ class Endpoint:
             raise e
 
     @staticmethod
-    def build_url(url, domain=None, method=None, **kwargs):
+    def build_url(
+        url: dict[str, str],
+        domain: dict | None = None,
+        method: str | None = None,
+        **kwargs: Any,
+    ):
         """Build final request url using predefined handlers.
 
         Note: Some urls are being built in Config class, as they can't be generated dynamically.

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -84,7 +84,7 @@ class Config:
         self.ex_handler: bool = True
         self.api_url = api_url or self.DEFAULT_API_URL
 
-    def __getitem__(self, key: str) -> tuple[dict[str, Any], dict[str, str]]:
+    def __getitem__(self, key: str) -> tuple[Any, dict[str, str]]:
         """Parse incoming split attr name, check it and prepare endpoint url.
 
         Most urls generated here can't be generated dynamically as we are doing this
@@ -100,7 +100,7 @@ class Config:
         modified = False
         # Domains section
         if key.lower() == "domainlist":
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, self.version + "/"),
                 "keys": ["domainlist"],
             }
@@ -117,37 +117,37 @@ class Config:
             elif "webprefix" in split:
                 final_keys = ["web_prefix"]
 
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, self.version + "/domains/"),
                 "keys": final_keys,
             }
             modified = True
         # Messages section
         if key.lower() == "messages":
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, self.version + "/"),
                 "keys": ["messages"],
             }
         if key.lower() == "mimemessage":
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, self.version + "/"),
                 "keys": ["messages.mime"],
             }
             modified = True
         if key.lower() == "resendmessage":
-            url = {"keys": ["resendmessage"]}
+            url = {"keys": ["resendmessage"]}  # type: ignore[assignment]
             modified = True
 
         # IPpools section
         if key.lower() == "ippools":
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, self.version + "/"),
                 "keys": ["ip_pools"],
             }
             modified = True
         # Email Validation section
         if "addressvalidate" in key.lower():
-            url = {
+            url = {  # type: ignore[assignment]
                 "base": urljoin(self.api_url, "v4" + "/address/validate"),
                 "keys": key.split("_"),
             }
@@ -155,7 +155,7 @@ class Config:
 
         if not modified:
             url = urljoin(self.api_url, self.version + "/")
-            url = {"base": url, "keys": key.split("_")}
+            url = {"base": url, "keys": key.split("_")}  # type: ignore[assignment]
         return url, headers
 
 

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -6,7 +6,7 @@ from typing import Any
 from typing import Callable
 from urllib.parse import urljoin
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 from mailgun.handlers.default_handler import handle_default
 from mailgun.handlers.domains_handler import handle_domainlist
@@ -30,7 +30,7 @@ from mailgun.handlers.templates_handler import handle_templates
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from requests.models import Response
+    from requests.models import Response  # type: ignore[import-untyped]
 
 
 HANDLERS: dict[str, Callable] = {  # type: ignore[type-arg]

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -206,7 +206,7 @@ class Endpoint:
         :type kwargs: Any
         :return: server response from API
         """
-        built_url: str = self.build_url(url, domain=domain, method=method, **kwargs)
+        built_url: Any = self.build_url(url, domain=domain, method=method, **kwargs)
         req_method = getattr(requests, method)
 
         try:

--- a/mailgun/examples/domain_examples.py
+++ b/mailgun/examples/domain_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_domains():
+def get_domains() -> None:
     """
     GET /domains
     :return:
@@ -21,7 +21,7 @@ def get_domains():
 # Get domain
 
 
-def get_simple_domain():
+def get_simple_domain() -> None:
     """
     GET /domains/<domain>
     :return:
@@ -31,7 +31,7 @@ def get_simple_domain():
     print(data.json())
 
 
-def verify_domain():
+def verify_domain() -> None:
     """
     PUT /domains/<domain>/verify
     :return:
@@ -41,7 +41,7 @@ def verify_domain():
     print(data.json())
 
 
-def add_domain():
+def add_domain() -> None:
     """
     POST /domains
     :return:
@@ -58,7 +58,7 @@ def add_domain():
     print(request.status_code)
 
 
-def delete_domain():
+def delete_domain() -> None:
     """
     DELETE /domains/<domain>
     :return:
@@ -69,7 +69,7 @@ def delete_domain():
     print(request.status_code)
 
 
-def get_credentials():
+def get_credentials() -> None:
     """
     GET /domains/<domain>/credentials
     :return:
@@ -78,7 +78,7 @@ def get_credentials():
     print(request.json())
 
 
-def post_credentials():
+def post_credentials() -> None:
     """
     POST /domains/<domain>/credentials
     :return:
@@ -88,7 +88,7 @@ def post_credentials():
     print(request.json())
 
 
-def put_credentials():
+def put_credentials() -> None:
     """
     PUT /domains/<domain>/credentials/<login>
     :return:
@@ -100,7 +100,7 @@ def put_credentials():
     print(request.json())
 
 
-def delete_credentials():
+def delete_credentials() -> None:
     """
     DELETE /domains/<domain>/credentials/<login>
     :return:
@@ -111,7 +111,7 @@ def delete_credentials():
     print(request.json())
 
 
-def get_connections():
+def get_connections() -> None:
     """
     GET /domains/<domain>/connection
     :return:
@@ -120,7 +120,7 @@ def get_connections():
     print(request.json())
 
 
-def put_connections():
+def put_connections() -> None:
     """
     PUT /domains/<domain>/connection
     :return:
@@ -130,7 +130,7 @@ def put_connections():
     print(request.json())
 
 
-def get_tracking():
+def get_tracking() -> None:
     """
     GET /domains/<domain>/tracking
     :return:
@@ -139,7 +139,7 @@ def get_tracking():
     print(request.json())
 
 
-def put_open_tracking():
+def put_open_tracking() -> None:
     """
     PUT /domains/<domain>/tracking/open
     :return:
@@ -149,7 +149,7 @@ def put_open_tracking():
     print(request.json())
 
 
-def put_click_tracking():
+def put_click_tracking() -> None:
     """
     PUT /domains/<domain>/tracking/click
     :return:
@@ -161,7 +161,7 @@ def put_click_tracking():
     print(request.json())
 
 
-def put_unsub_tracking():
+def put_unsub_tracking() -> None:
     """
     PUT /domains/<domain>/tracking/unsubscribe
     :return:
@@ -177,7 +177,7 @@ def put_unsub_tracking():
     print(request.json())
 
 
-def put_dkim_authority():
+def put_dkim_authority() -> None:
     """
     PUT /domains/<domain>/dkim_authority
     :return:
@@ -187,7 +187,7 @@ def put_dkim_authority():
     print(request.json())
 
 
-def put_dkim_selector():
+def put_dkim_selector() -> None:
     """
     PUT /domains/<domain>/dkim_selector
     :return:
@@ -197,7 +197,7 @@ def put_dkim_selector():
     print(request.json())
 
 
-def put_web_prefix():
+def put_web_prefix() -> None:
     """
     PUT /domains/<domain>/web_prefix
     :return:

--- a/mailgun/examples/email_validation_examples.py
+++ b/mailgun/examples/email_validation_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_single_validate():
+def get_single_validate() -> None:
     """
     GET /v4/address/validate
     :return:
@@ -19,7 +19,7 @@ def get_single_validate():
     print(req.json())
 
 
-def post_single_validate():
+def post_single_validate() -> None:
     """
     POST /v4/address/validate
     :return:
@@ -30,7 +30,7 @@ def post_single_validate():
     print(req.json())
 
 
-def get_bulk_validate():
+def get_bulk_validate() -> None:
     """
     GET /v4/address/validate/bulk
     :return:
@@ -40,7 +40,7 @@ def get_bulk_validate():
     print(req.json())
 
 
-def post_bulk_list_validate():
+def post_bulk_list_validate() -> None:
     """
     POST /v4/address/validate/bulk/<list_id>
     :return:
@@ -53,7 +53,7 @@ def post_bulk_list_validate():
     print(req.json())
 
 
-def get_bulk_list_validate():
+def get_bulk_list_validate() -> None:
     """
     GET /v4/address/validate/bulk/<list_id>
     :return:
@@ -62,7 +62,7 @@ def get_bulk_list_validate():
     print(req.json())
 
 
-def delete_bulk_list_validate():
+def delete_bulk_list_validate() -> None:
     """
     DELETE /v4/address/validate/bulk/<list_id>
     :return:
@@ -71,7 +71,7 @@ def delete_bulk_list_validate():
     print(req.json())
 
 
-def get_preview():
+def get_preview() -> None:
     """
     GET /v4/address/validate/preview
     :return:
@@ -80,7 +80,7 @@ def get_preview():
     print(req.json())
 
 
-def post_preview():
+def post_preview() -> None:
     """
     POST /v4/address/validate/preview/<list_id>
     :return:
@@ -93,7 +93,7 @@ def post_preview():
     print(req.json())
 
 
-def delete_preview():
+def delete_preview() -> None:
     """
     DELETE /v4/address/validate/preview/<list_id>
     :return:

--- a/mailgun/examples/events_examples.py
+++ b/mailgun/examples/events_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_domain_events():
+def get_domain_events() -> None:
     """
     GET /<domain>/events
     :return:
@@ -18,7 +18,7 @@ def get_domain_events():
     print(req.json())
 
 
-def view_message_with_storage_url():
+def view_message_with_storage_url() -> None:
     """
     https://sw.api.mailgun.net/v3/domains/2048.zeefarmer.com/messages/{storage_url}
     :return:
@@ -32,7 +32,7 @@ def view_message_with_storage_url():
     print(req.json())
 
 
-def events_by_recipient():
+def events_by_recipient() -> None:
     """
     GET /<domain>/events
     :return:
@@ -48,7 +48,7 @@ def events_by_recipient():
     print(req.json())
 
 
-def events_rejected_or_failed():
+def events_rejected_or_failed() -> None:
     """
     GET /<domain>/events
     :return:

--- a/mailgun/examples/inbox_placement_examples.py
+++ b/mailgun/examples/inbox_placement_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def post_inbox():
+def post_inbox() -> None:
     """
     POST /v3/inbox/tests
     :return:
@@ -25,7 +25,7 @@ def post_inbox():
     print(req.json())
 
 
-def get_all_inbox():
+def get_all_inbox() -> None:
     """
     GET /v3/inbox/tests
     :return:
@@ -34,7 +34,7 @@ def get_all_inbox():
     print(req.json())
 
 
-def get_inbox_placement_test():
+def get_inbox_placement_test() -> None:
     """
     GET /v3/inbox/tests/<test_id>
     :return:
@@ -43,7 +43,7 @@ def get_inbox_placement_test():
     print(req.json())
 
 
-def delete_inbox_placement_test():
+def delete_inbox_placement_test() -> None:
     """
     DELETE /v3/inbox/tests/<test_id>
     :return:
@@ -52,7 +52,7 @@ def delete_inbox_placement_test():
     print(req.json())
 
 
-def inbox_placement_test_counters():
+def inbox_placement_test_counters() -> None:
     """
     GET /v3/inbox/tests/<test_id>/counters
     :return:
@@ -63,7 +63,7 @@ def inbox_placement_test_counters():
     print(req.json())
 
 
-def get_inbox_placement_test_checks():
+def get_inbox_placement_test_checks() -> None:
     """
     GET /v3/inbox/tests/<test_id>/checks
     :return:
@@ -74,7 +74,7 @@ def get_inbox_placement_test_checks():
     print(req.json())
 
 
-def get_single_placement_check_test():
+def get_single_placement_check_test() -> None:
     """
     GET /v3/inbox/tests/<test_id>/checks/<address>
     :return:

--- a/mailgun/examples/ip_pools_examples.py
+++ b/mailgun/examples/ip_pools_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_ippools():
+def get_ippools() -> None:
     """
     GET /v1/ip_pools
     :return:
@@ -18,7 +18,7 @@ def get_ippools():
     print(req.json())
 
 
-def create_ippool():
+def create_ippool() -> None:
     """
     POST /v1/ip_pools
     :return:
@@ -28,7 +28,7 @@ def create_ippool():
     print(req_post.json())
 
 
-def update_ippool():
+def update_ippool() -> None:
     """
     PATCH /v1/ip_pools/{pool_id}
     :return:
@@ -43,7 +43,7 @@ def update_ippool():
     print(req.json())
 
 
-def delete_ippool():
+def delete_ippool() -> None:
     """
     DELETE /v1/ip_pools/{pool_id}
     :return:
@@ -52,7 +52,7 @@ def delete_ippool():
     print(req.json())
 
 
-def link_ippool():
+def link_ippool() -> None:
     """
     POST /v3/domains/{domain_name}/ips
     :return:
@@ -62,7 +62,7 @@ def link_ippool():
     print(req.json())
 
 
-def unlink_ippool():
+def unlink_ippool() -> None:
     """
     DELETE /v3/domains/{domain_name}/ips/ip_pool
     :return:

--- a/mailgun/examples/ips_examples.py
+++ b/mailgun/examples/ips_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_ips():
+def get_ips() -> None:
     """
     GET /ips
     :return:
@@ -18,7 +18,7 @@ def get_ips():
     print(req.json())
 
 
-def get_single_ip():
+def get_single_ip() -> None:
     """
     GET /ips/<ip>
     :return:
@@ -27,7 +27,7 @@ def get_single_ip():
     print(req.json())
 
 
-def get_domain_ips():
+def get_domain_ips() -> None:
     """
     GET /domains/<domain>/ips
     :return:
@@ -36,7 +36,7 @@ def get_domain_ips():
     print(request.json())
 
 
-def post_domains_ip():
+def post_domains_ip() -> None:
     """
     POST /domains/<domain>/ips
     :return:
@@ -46,7 +46,7 @@ def post_domains_ip():
     print(request.json())
 
 
-def delete_domain_ip():
+def delete_domain_ip() -> None:
     """
     DELETE /domains/<domain>/ips/<ip>
     :return:

--- a/mailgun/examples/mailing_lists_examples.py
+++ b/mailgun/examples/mailing_lists_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_pages():
+def get_pages() -> None:
     """
     GET /lists/pages
     :return:
@@ -18,7 +18,7 @@ def get_pages():
     print(req.json())
 
 
-def get_lists_address():
+def get_lists_address() -> None:
     """
     GET /lists/<address>
     :return:
@@ -27,7 +27,7 @@ def get_lists_address():
     print(req.json())
 
 
-def post_lists():
+def post_lists() -> None:
     """
     POST /lists
     :return:
@@ -41,7 +41,7 @@ def post_lists():
     print(req.json())
 
 
-def put_lists():
+def put_lists() -> None:
     """
     PUT /lists/<address>
     :return:
@@ -52,7 +52,7 @@ def put_lists():
     print(req.json())
 
 
-def post_address_validate():
+def post_address_validate() -> None:
     """
     POST /lists/<address>/validate
     :return:
@@ -63,7 +63,7 @@ def post_address_validate():
     print(req.json())
 
 
-def get_validate_address():
+def get_validate_address() -> None:
     """
     GET /lists/<address>/validate
     :return:
@@ -74,7 +74,7 @@ def get_validate_address():
     print(req.json())
 
 
-def delete_validate_job():
+def delete_validate_job() -> None:
     """
     DELETE /lists/<address>/validate
     :return:
@@ -85,7 +85,7 @@ def delete_validate_job():
     print(req.json())
 
 
-def get_lists_members():
+def get_lists_members() -> None:
     """
     GET /lists/<address>/members/pages
     :return:
@@ -96,7 +96,7 @@ def get_lists_members():
     print(req.json())
 
 
-def get_member_from_list():
+def get_member_from_list() -> None:
     """
     GET /lists/<address>/members/<member_address>
     :return:
@@ -110,7 +110,7 @@ def get_member_from_list():
     print(req.json())
 
 
-def post_member_list():
+def post_member_list() -> None:
     """
     POST /lists/<address>/members
     :return:
@@ -128,7 +128,7 @@ def post_member_list():
     print(req.json())
 
 
-def put_member_list():
+def put_member_list() -> None:
     """
     PUT /lists/<address>/members/<member_address>
     :return:
@@ -151,7 +151,7 @@ def put_member_list():
     print(req.json())
 
 
-def post_members_json():
+def post_members_json() -> None:
     """
     POST /lists/<address>/members.json
     :return:
@@ -171,7 +171,7 @@ def post_members_json():
     print(req.json())
 
 
-def delete_members_list():
+def delete_members_list() -> None:
     """
     DELETE /lists/<address>/members/<member_address>
     :return:
@@ -184,7 +184,7 @@ def delete_members_list():
     print(req.json())
 
 
-def delete_lists_address():
+def delete_lists_address() -> None:
     """
     DELETE /lists/<address>
     :return:

--- a/mailgun/examples/messages_examples.py
+++ b/mailgun/examples/messages_examples.py
@@ -3,9 +3,9 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
-html = """<body style="margin: 0; padding: 0;">
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
+html: str = """<body style="margin: 0; padding: 0;">
  <table border="1" cellpadding="0" cellspacing="0" width="100%">
   <tr>
    <td>
@@ -14,10 +14,10 @@ html = """<body style="margin: 0; padding: 0;">
   </tr>
  </table>
 </body>"""
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def post_message():
+def post_message() -> None:
     # Messages
     # POST /<domain>/messages
     data = {
@@ -45,7 +45,7 @@ def post_message():
     print(req.json())
 
 
-def post_mime():
+def post_mime() -> None:
     # Mime messages
     # POST /<domain>/messages.mime
     mime_data = {
@@ -61,7 +61,7 @@ def post_mime():
     print(req.json())
 
 
-def post_no_tracking():
+def post_no_tracking() -> None:
     # Message no tracking
     data = {
         "from": os.environ["MESSAGES_FROM"],
@@ -76,7 +76,7 @@ def post_no_tracking():
     print(req.json())
 
 
-def post_scheduled():
+def post_scheduled() -> None:
     # Scheduled message
     data = {
         "from": os.environ["MESSAGES_FROM"],
@@ -91,7 +91,7 @@ def post_scheduled():
     print(req.json())
 
 
-def post_message_tags():
+def post_message_tags() -> None:
     # Message Tags
     data = {
         "from": os.environ["MESSAGES_FROM"],
@@ -106,7 +106,7 @@ def post_message_tags():
     print(req.json())
 
 
-def resend_message():
+def resend_message() -> None:
     data = {"to": ["spidlisn@gmail.com", "mailgun@2048.zeefarmer.com"]}
 
     params = {

--- a/mailgun/examples/routes_examples.py
+++ b/mailgun/examples/routes_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_routes():
+def get_routes() -> None:
     """
     GET /routes
     :return:
@@ -19,7 +19,7 @@ def get_routes():
     print(req.json())
 
 
-def get_route_by_id():
+def get_route_by_id() -> None:
     """
     GET /routes/<id>
     :return:
@@ -28,7 +28,7 @@ def get_route_by_id():
     print(req.json())
 
 
-def post_routes():
+def post_routes() -> None:
     """
     POST /routes
     :return:
@@ -43,7 +43,7 @@ def post_routes():
     print(req.json())
 
 
-def put_route():
+def put_route() -> None:
     """
     PUT /routes/<id>
     :return:
@@ -60,7 +60,7 @@ def put_route():
     print(req.json())
 
 
-def delete_route():
+def delete_route() -> None:
     """
     DELETE /routes/<id>
     :return:

--- a/mailgun/examples/stats_examples.py
+++ b/mailgun/examples/stats_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_stats_total():
+def get_stats_total() -> None:
     params = {"event": ["accepted", "delivered", "failed"], "duration": "1m"}
 
     req = client.stats_total.get(filters=params, domain=domain)

--- a/mailgun/examples/suppressions_examples.py
+++ b/mailgun/examples/suppressions_examples.py
@@ -3,15 +3,15 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 # Bounces
 
 
-def get_bounces():
+def get_bounces() -> None:
     """
     GET /<domain>/bounces
     :return:
@@ -20,7 +20,7 @@ def get_bounces():
     print(req.json())
 
 
-def post_bounces():
+def post_bounces() -> None:
     """
     POST /<domain>/bounces
     :return:
@@ -30,7 +30,7 @@ def post_bounces():
     print(req.json())
 
 
-def get_single_bounce():
+def get_single_bounce() -> None:
     """
     GET /<domain>/bounces/<address>
     :return:
@@ -39,7 +39,7 @@ def get_single_bounce():
     print(req.json())
 
 
-def add_multiple_bounces():
+def add_multiple_bounces() -> None:
     """
     POST /<domain>/bounces, Content-Type: application/json
     :return:
@@ -52,7 +52,7 @@ def add_multiple_bounces():
     print(req.json())
 
 
-def import_bounce_list():
+def import_bounce_list() -> None:
     """
     POST /<domain>/bounces/import, Content-Type: multipart/form-data
     :return:
@@ -63,7 +63,7 @@ def import_bounce_list():
     print(req.json())
 
 
-def delete_single_bounce():
+def delete_single_bounce() -> None:
     """
     DELETE /<domain>/bounces/<address>
     :return:
@@ -72,7 +72,7 @@ def delete_single_bounce():
     print(req.json())
 
 
-def delete_bounce_list():
+def delete_bounce_list() -> None:
     """
     DELETE /<domain>/bounces
     :return:
@@ -84,7 +84,7 @@ def delete_bounce_list():
 # Unsubscribes
 
 
-def get_unsubs():
+def get_unsubs() -> None:
     """
     GET /<domain>/unsubscribes
     :return:
@@ -93,7 +93,7 @@ def get_unsubs():
     print(req.json())
 
 
-def get_single_unsub():
+def get_single_unsub() -> None:
     """
     GET /<domain>/unsubscribes/<address>
     :return:
@@ -102,7 +102,7 @@ def get_single_unsub():
     print(req.json())
 
 
-def create_single_unsub():
+def create_single_unsub() -> None:
     """
     POST /<domain>/unsubscribes
     :return:
@@ -112,7 +112,7 @@ def create_single_unsub():
     print(req.json())
 
 
-def create_multiple_unsub():
+def create_multiple_unsub() -> None:
     """
     POST /<domain>/unsubscribes, Content-Type: application/json
     :return:
@@ -136,7 +136,7 @@ def create_multiple_unsub():
     print(req.json())
 
 
-def import_list_unsubs():
+def import_list_unsubs() -> None:
     """
     POST /<domain>/unsubscribes/import, Content-Type: multipart/form-data
     :return:
@@ -149,7 +149,7 @@ def import_list_unsubs():
     print(req.json())
 
 
-def delete_single_unsub():
+def delete_single_unsub() -> None:
     """
     DELETE /<domain>/unsubscribes/<address>
     :return:
@@ -160,7 +160,7 @@ def delete_single_unsub():
     print(req.json())
 
 
-def delete_all_unsubs():
+def delete_all_unsubs() -> None:
     """
     DELETE /<domain>/unsubscribes/
     :return:
@@ -172,7 +172,7 @@ def delete_all_unsubs():
 # Complaints
 
 
-def get_complaints():
+def get_complaints() -> None:
     """
     GET /<domain>/complaints
 
@@ -182,7 +182,7 @@ def get_complaints():
     print(req.json())
 
 
-def add_complaints():
+def add_complaints() -> None:
     """
     POST /<domain>/complaints
     :return:
@@ -192,7 +192,7 @@ def add_complaints():
     print(req.json())
 
 
-def add_multiple_complaints():
+def add_multiple_complaints() -> None:
     """
     POST /<domain>/complaints, Content-Type: application/json
     :return:
@@ -210,7 +210,7 @@ def add_multiple_complaints():
     print(req.json())
 
 
-def import_complaint_list():
+def import_complaint_list() -> None:
     """
     POST /<domain>/complaints/import, Content-Type: multipart/form-data
     :return:
@@ -221,7 +221,7 @@ def import_complaint_list():
     print(req.json())
 
 
-def delete_single_complaint():
+def delete_single_complaint() -> None:
     """
     DELETE /<domain>/complaints/<address>
     :return:
@@ -232,7 +232,7 @@ def delete_single_complaint():
     print(req.json())
 
 
-def delete_all_complaints():
+def delete_all_complaints() -> None:
     """
     DELETE /<domain>/complaints/
     :return:
@@ -244,7 +244,7 @@ def delete_all_complaints():
 # Whitelists
 
 
-def get_whitelists():
+def get_whitelists() -> None:
     """
     GET /<domain>/whitelists
     :return:
@@ -253,7 +253,7 @@ def get_whitelists():
     print(req.json())
 
 
-def create_whitelist():
+def create_whitelist() -> None:
     """
     POST /<domain>/whitelists
     :return:
@@ -263,7 +263,7 @@ def create_whitelist():
     print(req.json())
 
 
-def get_single_whitelist():
+def get_single_whitelist() -> None:
     """
     GET /<domain>/whitelists/<address or domain>
     :return:
@@ -273,7 +273,7 @@ def get_single_whitelist():
     print(req.json())
 
 
-def import_list_whitelists():
+def import_list_whitelists() -> None:
     """
     POST /<domain>/whitelists/import, Content-Type: multipart/form-data
     :return:
@@ -284,7 +284,7 @@ def import_list_whitelists():
     print(req.json())
 
 
-def delete_single_whitelist():
+def delete_single_whitelist() -> None:
     """
     DELETE /<domain>/whitelists/<address or domain>
     :return:

--- a/mailgun/examples/tags_examples.py
+++ b/mailgun/examples/tags_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_tags():
+def get_tags() -> None:
     """
     GET /<domain>/tags
     :return:
@@ -18,7 +18,7 @@ def get_tags():
     print(req.json())
 
 
-def get_single_tag():
+def get_single_tag() -> None:
     """
     GET /<domain>/tags/<tag>
     :return:
@@ -27,7 +27,7 @@ def get_single_tag():
     print(req.json())
 
 
-def put_single_tag():
+def put_single_tag() -> None:
     """
     PUT /<domain>/tags/<tag>
     :return:
@@ -38,7 +38,7 @@ def put_single_tag():
     print(req.json())
 
 
-def get_tag_stats():
+def get_tag_stats() -> None:
     """
     GET /<domain>/tags/<tag>/stats
     :return:
@@ -48,7 +48,7 @@ def get_tag_stats():
     print(req.json())
 
 
-def delete_tag():
+def delete_tag() -> None:
     """
     DELETE /<domain>/tags/<tag>
     :return:
@@ -57,7 +57,7 @@ def delete_tag():
     print(req.json())
 
 
-def get_aggregate_countries():
+def get_aggregate_countries() -> None:
     """
     GET /<domain>/tags/<tag>/stats/aggregates/countries
     :return:
@@ -68,7 +68,7 @@ def get_aggregate_countries():
     print(req.json())
 
 
-def get_aggregate_providers():
+def get_aggregate_providers() -> None:
     """
     GET /<domain>/tags/<tag>/stats/aggregates/providers
     :return:
@@ -79,7 +79,7 @@ def get_aggregate_providers():
     print(req.json())
 
 
-def get_aggregate_devices():
+def get_aggregate_devices() -> None:
     """
     GET /<domain>/tags/<tag>/stats/aggregates/devices
     :return:

--- a/mailgun/examples/templates_examples.py
+++ b/mailgun/examples/templates_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def post_template():
+def post_template() -> None:
     """
     POST /<domain>/templates
     :return:
@@ -26,7 +26,7 @@ def post_template():
     print(req.json())
 
 
-def get_template():
+def get_template() -> None:
     """
     GET /<domain>/templates/<name>
     :return:
@@ -38,7 +38,7 @@ def get_template():
     print(req.json())
 
 
-def update_template():
+def update_template() -> None:
     """
     PUT /<domain>/templates/<name>
     :return:
@@ -49,7 +49,7 @@ def update_template():
     print(req.json())
 
 
-def delete_template():
+def delete_template() -> None:
     """
     DELETE /<domain>/templates/<name>
     :return:
@@ -58,7 +58,7 @@ def delete_template():
     print(req.json())
 
 
-def get_domain_templates():
+def get_domain_templates() -> None:
     """
     GET /<domain>/templates
     :return:
@@ -68,7 +68,7 @@ def get_domain_templates():
     print(req.json())
 
 
-def delete_templates():
+def delete_templates() -> None:
     """
     DELETE /<domain>/templates
     :return:
@@ -77,7 +77,7 @@ def delete_templates():
     print(req.json())
 
 
-def create_new_template_version():
+def create_new_template_version() -> None:
     """
     POST /<domain>/templates/<template>/versions
     :return:
@@ -95,7 +95,7 @@ def create_new_template_version():
     print(req.json())
 
 
-def get_template_version():
+def get_template_version() -> None:
     """
     GET /<domain>/templates/<name>/versions/<tag>
     :return:
@@ -106,7 +106,7 @@ def get_template_version():
     print(req.json())
 
 
-def update_template_version():
+def update_template_version() -> None:
     """
     PUT /<domain>/templates/<name>/versions/<tag>
     :return:
@@ -123,7 +123,7 @@ def update_template_version():
     print(req.json())
 
 
-def delete_template_version():
+def delete_template_version() -> None:
     """
     DELETE /<domain>/templates/<template>/versions/<version>
     :return:
@@ -134,7 +134,7 @@ def delete_template_version():
     print(req.json())
 
 
-def get_all_versions():
+def get_all_versions() -> None:
     """
     GET /<domain>/templates/<template>/versions
     :return:

--- a/mailgun/examples/webhooks_examples.py
+++ b/mailgun/examples/webhooks_examples.py
@@ -3,13 +3,13 @@ import os
 from mailgun.client import Client
 
 
-key = os.environ["APIKEY"]
-domain = os.environ["DOMAIN"]
+key: str = os.environ["APIKEY"]
+domain: str = os.environ["DOMAIN"]
 
-client = Client(auth=("api", key))
+client: Client = Client(auth=("api", key))
 
 
-def get_webhooks():
+def get_webhooks() -> None:
     """
     GET /domains/<domain>/webhooks
     :return:
@@ -18,7 +18,7 @@ def get_webhooks():
     print(req.json())
 
 
-def create_webhook():
+def create_webhook() -> None:
     """
     POST /domains/<domain>/webhooks
     :return:
@@ -29,7 +29,7 @@ def create_webhook():
     print(req.json())
 
 
-def put_webhook():
+def put_webhook() -> None:
     """
     PUT /domains/<domain>/webhooks/<webhookname>
     :return:
@@ -40,7 +40,7 @@ def put_webhook():
     print(req.json())
 
 
-def delete_webhook():
+def delete_webhook() -> None:
     """
     DELETE /domains/<domain>/webhooks/<webhookname>
     :return:

--- a/mailgun/handlers/default_handler.py
+++ b/mailgun/handlers/default_handler.py
@@ -5,12 +5,20 @@ Messages doc: https://documentation.mailgun.com/en/latest/api-sending.html
 Stats doc: https://documentation.mailgun.com/en/latest/api-stats.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 from .error_handler import ApiError
 
 
-def handle_default(url, domain, _method, **_):
+def handle_default(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **_: Any,
+) -> Any:
     """Provide default handler for endpoints with single url pattern (events, messages, stats).
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/domains_handler.py
+++ b/mailgun/handlers/domains_handler.py
@@ -3,13 +3,21 @@
 Doc: https://documentation.mailgun.com/en/latest/api-domains.html#
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 from urllib.parse import urljoin
 
 from .error_handler import ApiError
 
 
-def handle_domainlist(url, _domain, _method, **_):
+def handle_domainlist(
+    url: dict[str, Any],
+    _domain: str | None,
+    _method: str | None,
+    **_: Any,
+) -> Any:
     """Handle a list of domains.
 
     :param url: Incoming URL dictionary
@@ -24,7 +32,12 @@ def handle_domainlist(url, _domain, _method, **_):
     return url["base"] + "domains"
 
 
-def handle_domains(url, domain, method, **kwargs):
+def handle_domains(
+    url: Any,
+    domain: str | None,
+    method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle a domain endpoint.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/domains_handler.py
+++ b/mailgun/handlers/domains_handler.py
@@ -49,6 +49,8 @@ def handle_domains(
     :param kwargs: kwargs
     :return: final url for domain endpoint
     """
+    # TODO: Refactor this logic
+    # fmt: off
     if "domains" in url["keys"]:
         domains_index = url["keys"].index("domains")
         url["keys"].pop(domains_index)
@@ -66,8 +68,6 @@ def handle_domains(
             url = kwargs["api_storage_url"]
         else:
             url = urljoin(url["base"], domain + final_keys)
-    # TODO: Refactor this logic
-    # fmt: off
     elif method in {"get", "post", "delete"}:
         if "domain_name" in kwargs:
             url = urljoin(url["base"], kwargs["domain_name"])

--- a/mailgun/handlers/email_validation_handler.py
+++ b/mailgun/handlers/email_validation_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 def handle_address_validate(
     url: dict[str, Any],
-    domain: str | None,
+    _domain: str | None,
     _method: str | None,
     **kwargs: Any,
 ) -> Any:

--- a/mailgun/handlers/email_validation_handler.py
+++ b/mailgun/handlers/email_validation_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-email-validation.html#email-validation
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_address_validate(url, _domain, _method, **kwargs):
+def handle_address_validate(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle email validation.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/inbox_placement_handler.py
+++ b/mailgun/handlers/inbox_placement_handler.py
@@ -3,12 +3,20 @@
 Doc: https://documentation.mailgun.com/en/latest/api-inbox-placement.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 from .error_handler import ApiError
 
 
-def handle_inbox(url, _domain, _method, **kwargs):
+def handle_inbox(
+    url: dict[str, Any],
+    _domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle inbox placement.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/ip_pools_handler.py
+++ b/mailgun/handlers/ip_pools_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 def handle_ippools(
     url: dict[str, Any],
-    domain: str | None,
+    _domain: str | None,
     _method: str | None,
     **kwargs: Any,
 ) -> Any:

--- a/mailgun/handlers/ip_pools_handler.py
+++ b/mailgun/handlers/ip_pools_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-ip-pools.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_ippools(url, _domain, _method, **kwargs):
+def handle_ippools(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle IP pools.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/ips_handler.py
+++ b/mailgun/handlers/ips_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-ips.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_ips(url, _domain, _method, **kwargs):
+def handle_ips(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle IPs.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/ips_handler.py
+++ b/mailgun/handlers/ips_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 def handle_ips(
     url: dict[str, Any],
-    domain: str | None,
+    _domain: str | None,
     _method: str | None,
     **kwargs: Any,
 ) -> Any:

--- a/mailgun/handlers/mailinglists_handler.py
+++ b/mailgun/handlers/mailinglists_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-mailinglists.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_lists(url, _domain, _method, **kwargs):
+def handle_lists(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Mailing List.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/mailinglists_handler.py
+++ b/mailgun/handlers/mailinglists_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 def handle_lists(
     url: dict[str, Any],
-    domain: str | None,
+    _domain: str | None,
     _method: str | None,
     **kwargs: Any,
 ) -> Any:

--- a/mailgun/handlers/messages_handler.py
+++ b/mailgun/handlers/messages_handler.py
@@ -3,10 +3,19 @@
 Doc: https://documentation.mailgun.com/en/latest/api-sending.html#
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from .error_handler import ApiError
 
 
-def handle_resend_message(_url, _domain, _method, **kwargs):
+def handle_resend_message(
+    _url: dict[str, Any],
+    _domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Resend message endpoint.
 
     :param _url: Incoming URL dictionary (it's not being used for this handler)

--- a/mailgun/handlers/routes_handler.py
+++ b/mailgun/handlers/routes_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-routes.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_routes(url, _domain, _method, **kwargs):
+def handle_routes(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Routes.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/routes_handler.py
+++ b/mailgun/handlers/routes_handler.py
@@ -11,7 +11,7 @@ from typing import Any
 
 def handle_routes(
     url: dict[str, Any],
-    domain: str | None,
+    _domain: str | None,
     _method: str | None,
     **kwargs: Any,
 ) -> Any:

--- a/mailgun/handlers/suppressions_handler.py
+++ b/mailgun/handlers/suppressions_handler.py
@@ -3,10 +3,18 @@
 Doc: https://documentation.mailgun.com/en/latest/api-suppressions.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 
-def handle_bounces(url, domain, _method, **kwargs):
+def handle_bounces(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Bounces.
 
     :param url: Incoming URL dictionary
@@ -26,7 +34,12 @@ def handle_bounces(url, domain, _method, **kwargs):
     return url
 
 
-def handle_unsubscribes(url, domain, _method, **kwargs):
+def handle_unsubscribes(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Unsubscribes.
 
     :param url: Incoming URL dictionary
@@ -46,7 +59,12 @@ def handle_unsubscribes(url, domain, _method, **kwargs):
     return url
 
 
-def handle_complaints(url, domain, _method, **kwargs):
+def handle_complaints(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Complaints.
 
     :param url: Incoming URL dictionary
@@ -66,7 +84,12 @@ def handle_complaints(url, domain, _method, **kwargs):
     return url
 
 
-def handle_whitelists(url, domain, _method, **kwargs):
+def handle_whitelists(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Whitelists.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/tags_handler.py
+++ b/mailgun/handlers/tags_handler.py
@@ -3,11 +3,19 @@
 Doc: https://documentation.mailgun.com/en/latest/api-tags.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 from urllib.parse import quote
 
 
-def handle_tags(url, domain, _method, **kwargs):
+def handle_tags(
+    url: Any,
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Tags.
 
     :param url: Incoming URL dictionary

--- a/mailgun/handlers/templates_handler.py
+++ b/mailgun/handlers/templates_handler.py
@@ -3,12 +3,20 @@
 Doc: https://documentation.mailgun.com/en/latest/api-templates.html
 """
 
+from __future__ import annotations
+
 from os import path
+from typing import Any
 
 from .error_handler import ApiError
 
 
-def handle_templates(url, domain, _method, **kwargs):
+def handle_templates(
+    url: dict[str, Any],
+    domain: str | None,
+    _method: str | None,
+    **kwargs: Any,
+) -> Any:
     """Handle Templates.
 
     :param url: Incoming URL dictionary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -357,7 +357,7 @@ strict_equality = true
 #    (^|/)test[^/]*\.py$    # files named "test*.py"
 #  )'''
 exclude = [
-    "mailgun/examples",
+    "mailgun/examples/*",
 ]
 
 # Configuring error messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -375,7 +375,7 @@ reportMissingImports = false
 
 [tool.bandit]
 # usage: bandit -c pyproject.toml -r .
-exclude_dirs = ["tests", "test.py"]
+exclude_dirs = ["tests", "tests.py"]
 tests = ["B201", "B301"]
 skips = ["B101", "B601"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,17 +70,17 @@ linting = [
     "bandit",
     "black>=21.7",
     "autoflake",
-    "flake8>=3.7.8",
+    "flake8>=3.7.8",  # the modular source code checker: pep8 pyflakes and co
     "pep8-naming",
-    "isort",
-    "yapf",
+    "isort",  # A Python utility / library to sort Python imports.
+    "yapf",  # A formatter for Python code
     "pycodestyle",
     "pydocstyle",
     "pyupgrade",
     "refurb",  # refurb doesn't support py39
-    "pre-commit",
-    "ruff",
-    "mypy",
+    "pre-commit",  # A framework for managing and maintaining multi-language pre-commit hooks.
+    "ruff",  # An extremely fast Python linter and code formatter, written in Rust.
+    "mypy",  # Optional static typing for Python
     "types-requests",   # mypy requests stub
     "pandas-stubs",  # mypy pandas stub
     "types-PyYAML",
@@ -89,6 +89,7 @@ linting = [
     "pylint",
     "pytype",  # a static type checker for any type hints you have put in your code
     "radon",
+    "safety", # Checks installed dependencies for known vulnerabilities and licenses.
     "vulture",
     # env variables
     "python-dotenv>=0.19.2",
@@ -180,6 +181,8 @@ line-length = 88
 
 # Assume Python 3.9.
 target-version = "py39"
+# Enumerate all fixed violations.
+show-fixes = true
 
 [tool.ruff.lint]
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
@@ -196,6 +199,7 @@ exclude = ["mailgun/examples/*"]
 
 #extend-select = ["W", "N", "UP", "B", "A", "C4", "PT", "SIM", "PD", "PLE", "RUF"]
 # Never enforce `E501` (line length violations).
+
 ignore = [
     # TODO: Fix unused function argument: `debug`, `kwargs`, and `method` in class Client
     "ARG001",  #  ARG001 Unused function argument: `debug`, `kwargs`, and `method` in class Client
@@ -299,6 +303,17 @@ per-file-ignores = [
 max-line-length = 88
 count = true
 
+[tool.yapf]
+based_on_style = "facebook"
+SPLIT_BEFORE_BITWISE_OPERATOR = true
+SPLIT_BEFORE_ARITHMETIC_OPERATOR = true
+SPLIT_BEFORE_LOGICAL_OPERATOR = true
+SPLIT_BEFORE_DOT = true
+
+[tool.yapfignore]
+ignore_patterns = [
+]
+
 [tool.mypy]
 strict = true
 # Adapted from this StackOverflow post:
@@ -346,7 +361,6 @@ exclude = [
 ]
 
 # Configuring error messages
-show-fixes = true
 show_error_context = false
 show_column_numbers = false
 show_error_codes = true
@@ -404,4 +418,22 @@ subprocess = [
   "subprocess.call",
   "subprocess.check_call",
   "subprocess.check_output"
+]
+
+[tool.coverage.run]
+source_pkgs = ["mailgun"]
+branch = true
+parallel = true
+omit = [
+    "mailgun/examples/*",
+]
+
+[tool.coverage.paths]
+tests = ["tests.py"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "no cov",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
 ]

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,7 @@ from mailgun.client import Client
 
 
 class MessagesTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -24,11 +24,11 @@ class MessagesTests(unittest.TestCase):
             "o:tag": "Python test",
         }
 
-    def test_post_right_message(self):
+    def test_post_right_message(self) -> None:
         req = self.client.messages.create(data=self.data, domain=self.domain)
         self.assertEqual(req.status_code, 200)
 
-    def test_post_wrong_message(self):
+    def test_post_wrong_message(self) -> None:
         req = self.client.messages.create(data={"from": "sdsdsd"}, domain=self.domain)
         self.assertEqual(req.status_code, 400)
 
@@ -41,7 +41,7 @@ class DomainTests(unittest.TestCase):
     generator to avoid this problems.
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -90,12 +90,12 @@ class DomainTests(unittest.TestCase):
             "dkim_selector": "s",
         }
 
-    def test_get_domain_list(self):
+    def test_get_domain_list(self) -> None:
         req = self.client.domainlist.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_post_domain(self):
+    def test_post_domain(self) -> None:
         #  ### Problem with smtp_password!!!!
         #
         self.client.domains.delete(domain=self.test_domain)
@@ -103,20 +103,20 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("Domain DNS records have been created", request.json()["message"])
 
-    def test_get_single_domain(self):
+    def test_get_single_domain(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         req = self.client.domains.get(domain_name=self.post_domain_data["name"])
 
         self.assertEqual(req.status_code, 200)
         self.assertIn("domain", req.json())
 
-    def test_verify_domain(self):
+    def test_verify_domain(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         req = self.client.domains.put(domain=self.post_domain_data["name"], verify=True)
         self.assertEqual(req.status_code, 200)
         self.assertIn("domain", req.json())
 
-    def test_delete_domain(self):
+    def test_delete_domain(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         request = self.client.domains.delete(domain=self.test_domain)
         self.assertEqual(
@@ -125,12 +125,12 @@ class DomainTests(unittest.TestCase):
         )
         self.assertEqual(request.status_code, 200)
 
-    def test_get_smtp_creds(self):
+    def test_get_smtp_creds(self) -> None:
         request = self.client.domains_credentials.get(domain=self.domain)
         self.assertEqual(request.status_code, 200)
         self.assertIn("items", request.json())
 
-    def test_post_domain_creds(self):
+    def test_post_domain_creds(self) -> None:
         request = self.client.domains_credentials.create(
             domain=self.domain,
             data=self.post_domain_creds,
@@ -138,7 +138,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_put_domain_creds(self):
+    def test_put_domain_creds(self) -> None:
         self.client.domains_credentials.create(
             domain=self.domain,
             data=self.post_domain_creds,
@@ -152,7 +152,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_delete_domain_creds(self):
+    def test_delete_domain_creds(self) -> None:
         self.client.domains_credentials.create(
             domain=self.domain,
             data=self.post_domain_creds,
@@ -164,7 +164,7 @@ class DomainTests(unittest.TestCase):
 
         self.assertEqual(request.status_code, 200)
 
-    def test_put_domain_connections(self):
+    def test_put_domain_connections(self) -> None:
         request = self.client.domains_connection.put(
             domain=self.domain,
             data=self.put_domain_connections_data,
@@ -173,7 +173,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_put_domain_tracking_open(self):
+    def test_put_domain_tracking_open(self) -> None:
         request = self.client.domains_tracking_open.put(
             domain=self.domain,
             data=self.put_domain_tracking_data,
@@ -181,7 +181,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_put_domain_tracking_click(self):
+    def test_put_domain_tracking_click(self) -> None:
         request = self.client.domains_tracking_click.put(
             domain=self.domain,
             data=self.put_domain_tracking_data,
@@ -189,7 +189,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_put_domain_unsubscribe(self):
+    def test_put_domain_unsubscribe(self) -> None:
         request = self.client.domains_tracking_unsubscribe.put(
             domain=self.domain,
             data=self.put_domain_unsubscribe_data,
@@ -197,7 +197,7 @@ class DomainTests(unittest.TestCase):
         self.assertEqual(request.status_code, 200)
         self.assertIn("message", request.json())
 
-    def test_put_dkim_authority(self):
+    def test_put_dkim_authority(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         request = self.client.domains_dkimauthority.put(
             domain=self.test_domain,
@@ -205,7 +205,7 @@ class DomainTests(unittest.TestCase):
         )
         self.assertIn("message", request.json())
 
-    def test_put_webprefix(self):
+    def test_put_webprefix(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         request = self.client.domains_webprefix.put(
             domain=self.test_domain,
@@ -213,7 +213,7 @@ class DomainTests(unittest.TestCase):
         )
         self.assertIn("message", request.json())
 
-    def test_put_dkim_selector(self):
+    def test_put_dkim_selector(self) -> None:
         self.client.domains.create(data=self.post_domain_data)
         request = self.client.domains_dkimselector.put(
             domain=self.domain,
@@ -223,7 +223,7 @@ class DomainTests(unittest.TestCase):
 
 
 class IpTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -234,24 +234,24 @@ class IpTests(unittest.TestCase):
             "ip": os.environ["DOMAINS_DEDICATED_IP"],
         }
 
-    def test_get_ip_from_domain(self):
+    def test_get_ip_from_domain(self) -> None:
         req = self.client.ips.get(domain=self.domain, params={"dedicated": "true"})
         self.assertIn("items", req.json())
         self.assertEqual(req.status_code, 200)
 
-    def test_get_ip_by_address(self):
+    def test_get_ip_by_address(self) -> None:
         self.client.domains_ips.create(domain=self.domain, data=self.ip_data)
         req = self.client.ips.get(domain=self.domain, ip=self.ip_data["ip"])
         self.assertIn("ip", req.json())
         self.assertEqual(req.status_code, 200)
 
     @pytest.mark.skip(reason="TODO: check this test")
-    def test_create_ip(self):
+    def test_create_ip(self) -> None:
         request = self.client.domains_ips.create(domain=self.domain, data=self.ip_data)
         self.assertEqual("success", request.json()["message"])
         self.assertEqual(request.status_code, 200)
 
-    def test_delete_ip(self):
+    def test_delete_ip(self) -> None:
         request = self.client.domains_ips.delete(
             domain=self.domain,
             ip=self.ip_data["ip"],
@@ -261,7 +261,7 @@ class IpTests(unittest.TestCase):
 
 
 class IpPoolsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -279,13 +279,13 @@ class IpPoolsTests(unittest.TestCase):
         }
         self.ippool_id = ""
 
-    def test_get_ippools(self):
+    def test_get_ippools(self) -> None:
         self.client.ippools.create(domain=self.domain, data=self.data)
         req = self.client.ippools.get(domain=self.domain)
         self.assertIn("ip_pools", req.json())
         self.assertEqual(req.status_code, 200)
 
-    def test_patch_ippool(self):
+    def test_patch_ippool(self) -> None:
         req_post = self.client.ippools.create(domain=self.domain, data=self.data)
         self.ippool_id = req_post.json()["pool_id"]
 
@@ -297,7 +297,7 @@ class IpPoolsTests(unittest.TestCase):
         self.assertEqual("success", req.json()["message"])
         self.assertEqual(req.status_code, 200)
 
-    def test_link_domain_ippool(self):
+    def test_link_domain_ippool(self) -> None:
         pool_create = self.client.ippools.create(domain=self.domain, data=self.data)
         self.ippool_id = pool_create.json()["pool_id"]
         self.client.ippools.patch(
@@ -312,7 +312,7 @@ class IpPoolsTests(unittest.TestCase):
 
         self.assertIn("message", req.json())
 
-    def test_delete_ippool(self):
+    def test_delete_ippool(self) -> None:
         req = self.client.ippools.create(domain=self.domain, data=self.data)
         self.ippool_id = req.json()["pool_id"]
         req_del = self.client.ippools.delete(domain=self.domain, pool_id=self.ippool_id)
@@ -320,7 +320,7 @@ class IpPoolsTests(unittest.TestCase):
 
 
 class EventsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -331,12 +331,12 @@ class EventsTests(unittest.TestCase):
             "event": "rejected",
         }
 
-    def test_events_get(self):
+    def test_events_get(self) -> None:
         req = self.client.events.get(domain=self.domain)
         self.assertIn("items", req.json())
         self.assertEqual(req.status_code, 200)
 
-    def test_event_params(self):
+    def test_event_params(self) -> None:
         req = self.client.events.get(domain=self.domain, filters=self.params)
 
         self.assertIn("items", req.json())
@@ -344,7 +344,7 @@ class EventsTests(unittest.TestCase):
 
 
 class StatsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -356,14 +356,14 @@ class StatsTests(unittest.TestCase):
             "duration": "1m",
         }
 
-    def test_stats_total_get(self):
+    def test_stats_total_get(self) -> None:
         req = self.client.stats_total.get(filters=self.params, domain=self.domain)
         self.assertIn("stats", req.json())
         self.assertEqual(req.status_code, 200)
 
 
 class TagsTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -381,17 +381,17 @@ class TagsTests(unittest.TestCase):
         }
         self.tag_name = "Python test"
 
-    def test_get_tags(self):
+    def test_get_tags(self) -> None:
         req = self.client.tags.get(domain=self.domain)
         self.assertIn("items", req.json())
         self.assertEqual(req.status_code, 200)
 
-    def test_tag_get_by_name(self):
+    def test_tag_get_by_name(self) -> None:
         req = self.client.tags.get(domain=self.domain, tag_name=self.tag_name)
         self.assertIn("tag", req.json())
         self.assertEqual(req.status_code, 200)
 
-    def test_tag_put(self):
+    def test_tag_put(self) -> None:
         req = self.client.tags.put(
             domain=self.domain,
             tag_name=self.tag_name,
@@ -401,7 +401,7 @@ class TagsTests(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_tags_stats_get(self):
+    def test_tags_stats_get(self) -> None:
         req = self.client.tags_stats.get(
             domain=self.domain,
             filters=self.stats_params,
@@ -411,7 +411,7 @@ class TagsTests(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("tag", req.json())
 
-    def test_tags_stats_aggregate_get(self):
+    def test_tags_stats_aggregate_get(self) -> None:
         req = self.client.tags_stats_aggregates_devices.get(
             domain=self.domain,
             filters=self.stats_params,
@@ -429,7 +429,7 @@ class TagsTests(unittest.TestCase):
 
 
 class BouncesTests(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -455,17 +455,17 @@ class BouncesTests(unittest.TestCase):
             },
         ]
 
-    def test_bounces_get(self):
+    def test_bounces_get(self) -> None:
         req = self.client.bounces.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_bounces_create(self):
+    def test_bounces_create(self) -> None:
         req = self.client.bounces.create(data=self.bounces_data, domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_bounces_get_address(self):
+    def test_bounces_get_address(self) -> None:
         self.client.bounces.create(data=self.bounces_data, domain=self.domain)
         req = self.client.bounces.get(
             domain=self.domain,
@@ -474,7 +474,7 @@ class BouncesTests(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_bounces_create_json(self):
+    def test_bounces_create_json(self) -> None:
         req = self.client.bounces.create(
             data=self.bounces_json_data,
             domain=self.domain,
@@ -483,7 +483,7 @@ class BouncesTests(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_bounces_delete_single(self):
+    def test_bounces_delete_single(self) -> None:
         self.client.bounces.create(data=self.bounces_data, domain=self.domain)
         req = self.client.bounces.delete(
             domain=self.domain,
@@ -492,14 +492,14 @@ class BouncesTests(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_bounces_delete_all(self):
+    def test_bounces_delete_all(self) -> None:
         req = self.client.bounces.delete(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
 
 class UnsubscribesTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -527,17 +527,17 @@ class UnsubscribesTest(unittest.TestCase):
             },
         ]
 
-    def test_unsub_create(self):
+    def test_unsub_create(self) -> None:
         req = self.client.unsubscribes.create(data=self.unsub_data, domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_unsub_get(self):
+    def test_unsub_get(self) -> None:
         req = self.client.unsubscribes.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_unsub_get_single(self):
+    def test_unsub_get_single(self) -> None:
         req = self.client.unsubscribes.get(
             domain=self.domain,
             unsubscribe_address=self.unsub_data["address"],
@@ -545,7 +545,7 @@ class UnsubscribesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_unsub_create_multiple(self):
+    def test_unsub_create_multiple(self) -> None:
         req = self.client.unsubscribes.create(
             data=self.unsub_json_data,
             domain=self.domain,
@@ -555,7 +555,7 @@ class UnsubscribesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_unsub_delete(self):
+    def test_unsub_delete(self) -> None:
         req = self.client.bounces.delete(
             domain=self.domain,
             unsubscribe_address=self.unsub_data["address"],
@@ -564,7 +564,7 @@ class UnsubscribesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_unsub_delete_all(self):
+    def test_unsub_delete_all(self) -> None:
         req = self.client.bounces.delete(domain=self.domain)
 
         self.assertEqual(req.status_code, 200)
@@ -572,7 +572,7 @@ class UnsubscribesTest(unittest.TestCase):
 
 
 class ComplaintsTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -595,18 +595,18 @@ class ComplaintsTest(unittest.TestCase):
             },
         ]
 
-    def test_compl_create(self):
+    def test_compl_create(self) -> None:
         req = self.client.complaints.create(data=self.compl_data, domain=self.domain)
 
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_compl_get_all(self):
+    def test_compl_get_all(self) -> None:
         req = self.client.complaints.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_compl_get_single(self):
+    def test_compl_get_single(self) -> None:
         self.client.complaints.create(data=self.compl_data, domain=self.domain)
         req = self.client.complaints.get(
             domain=self.domain,
@@ -615,7 +615,7 @@ class ComplaintsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_compl_create_multiple(self):
+    def test_compl_create_multiple(self) -> None:
         req = self.client.complaints.create(
             data=self.compl_json_data,
             domain=self.domain,
@@ -625,7 +625,7 @@ class ComplaintsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_compl_delete_single(self):
+    def test_compl_delete_single(self) -> None:
         self.client.complaints.create(
             data=self.compl_json_data,
             domain=self.domain,
@@ -639,14 +639,14 @@ class ComplaintsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_compl_delete_all(self):
+    def test_compl_delete_all(self) -> None:
         req = self.client.complaints.delete(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
 
 class WhiteListTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -669,12 +669,12 @@ class WhiteListTest(unittest.TestCase):
             },
         ]
 
-    def test_whitel_create(self):
+    def test_whitel_create(self) -> None:
         req = self.client.whitelists.create(data=self.whitel_data, domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_whitel_get_simple(self):
+    def test_whitel_get_simple(self) -> None:
         self.client.whitelists.create(data=self.whitel_data, domain=self.domain)
 
         req = self.client.whitelists.get(
@@ -685,7 +685,7 @@ class WhiteListTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("value", req.json())
 
-    def test_whitel_delete_simple(self):
+    def test_whitel_delete_simple(self) -> None:
         self.client.whitelists.create(data=self.whitel_data, domain=self.domain)
         req = self.client.whitelists.delete(
             domain=self.domain,
@@ -697,7 +697,7 @@ class WhiteListTest(unittest.TestCase):
 
 
 class RoutesTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -718,20 +718,20 @@ class RoutesTest(unittest.TestCase):
             "priority": 2,
         }
 
-    def test_routes_create(self):
+    def test_routes_create(self) -> None:
         req = self.client.routes.create(domain=self.domain, data=self.routes_data)
 
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_routes_get_all(self):
+    def test_routes_get_all(self) -> None:
         self.client.routes.create(domain=self.domain, data=self.routes_data)
         req = self.client.routes.get(domain=self.domain, filters=self.routes_params)
 
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_get_route_by_id(self):
+    def test_get_route_by_id(self) -> None:
         req_post = self.client.routes.create(domain=self.domain, data=self.routes_data)
         self.client.routes.create(domain=self.domain, data=self.routes_data)
         req = self.client.routes.get(
@@ -742,7 +742,7 @@ class RoutesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("route", req.json())
 
-    def test_routes_put(self):
+    def test_routes_put(self) -> None:
         req_post = self.client.routes.create(domain=self.domain, data=self.routes_data)
         req = self.client.routes.put(
             domain=self.domain,
@@ -753,7 +753,7 @@ class RoutesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("message", req.json())
 
-    def test_routes_delete(self):
+    def test_routes_delete(self) -> None:
         req_post = self.client.routes.create(domain=self.domain, data=self.routes_data)
         req = self.client.routes.delete(
             domain=self.domain,
@@ -765,7 +765,7 @@ class RoutesTest(unittest.TestCase):
 
 
 class WebhooksTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -781,7 +781,7 @@ class WebhooksTest(unittest.TestCase):
             "url": "https://twitter.com",
         }
 
-    def test_webhooks_create(self):
+    def test_webhooks_create(self) -> None:
         req = self.client.domains_webhooks.create(
             domain=self.domain,
             data=self.webhooks_data,
@@ -791,12 +791,12 @@ class WebhooksTest(unittest.TestCase):
         self.assertIn("message", req.json())
         self.client.domains_webhooks_clicked.delete(domain=self.domain)
 
-    def test_webhooks_get(self):
+    def test_webhooks_get(self) -> None:
         req = self.client.domains_webhooks.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("webhooks", req.json())
 
-    def test_webhook_put(self):
+    def test_webhook_put(self) -> None:
         self.client.domains_webhooks.create(domain=self.domain, data=self.webhooks_data)
         req = self.client.domains_webhooks_clicked.put(
             domain=self.domain,
@@ -806,14 +806,14 @@ class WebhooksTest(unittest.TestCase):
         self.assertIn("message", req.json())
         self.client.domains_webhooks_clicked.delete(domain=self.domain)
 
-    def test_webhook_get_simple(self):
+    def test_webhook_get_simple(self) -> None:
         self.client.domains_webhooks.create(domain=self.domain, data=self.webhooks_data)
         req = self.client.domains_webhooks_clicked.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("webhook", req.json())
         self.client.domains_webhooks_clicked.delete(domain=self.domain)
 
-    def test_webhook_delete(self):
+    def test_webhook_delete(self) -> None:
         self.client.domains_webhooks.create(domain=self.domain, data=self.webhooks_data)
         req = self.client.domains_webhooks_clicked.delete(domain=self.domain)
         self.assertEqual(req.status_code, 200)
@@ -821,7 +821,7 @@ class WebhooksTest(unittest.TestCase):
 
 
 class MailingListsTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -860,17 +860,17 @@ class MailingListsTest(unittest.TestCase):
             '{"name": "Bob", "address": "bob2@example.com", "vars": {"age": 34}}]',
         }
 
-    def test_maillist_pages_get(self):
+    def test_maillist_pages_get(self) -> None:
         req = self.client.lists_pages.get(domain=self.domain)
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_maillist_lists_get(self):
+    def test_maillist_lists_get(self) -> None:
         req = self.client.lists.get(domain=self.domain, address=self.maillist_address)
         self.assertEqual(req.status_code, 200)
         self.assertIn("list", req.json())
 
-    def test_maillist_lists_create(self):
+    def test_maillist_lists_create(self) -> None:
         self.client.lists.delete(
             domain=self.domain,
             address=f"python_sdk@{self.domain}",
@@ -879,7 +879,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("list", req.json())
 
-    def test_maillists_lists_put(self):
+    def test_maillists_lists_put(self) -> None:
         self.client.lists.create(domain=self.domain, data=self.mailing_lists_data)
         req = self.client.lists.put(
             domain=self.domain,
@@ -889,7 +889,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("list", req.json())
 
-    def test_maillists_lists_delete(self):
+    def test_maillists_lists_delete(self) -> None:
         self.client.lists.create(domain=self.domain, data=self.mailing_lists_data)
         req = self.client.lists.delete(
             domain=self.domain,
@@ -897,7 +897,7 @@ class MailingListsTest(unittest.TestCase):
         )
         self.assertEqual(req.status_code, 200)
 
-    def test_maillists_lists_validate_create(self):
+    def test_maillists_lists_validate_create(self) -> None:
         req = self.client.lists.create(
             domain=self.domain,
             address=self.maillist_address,
@@ -907,7 +907,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 202)
         self.assertIn("message", req.json())
 
-    def test_maillists_lists_validate_get(self):
+    def test_maillists_lists_validate_get(self) -> None:
         req = self.client.lists.get(
             domain=self.domain,
             address=self.maillist_address,
@@ -917,7 +917,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("id", req.json())
 
-    def test_maillists_lists_validate_delete(self):
+    def test_maillists_lists_validate_delete(self) -> None:
         self.client.lists.create(
             domain=self.domain,
             address=self.maillist_address,
@@ -931,7 +931,7 @@ class MailingListsTest(unittest.TestCase):
 
         self.assertEqual(req.status_code, 200)
 
-    def test_maillists_lists_members_pages_get(self):
+    def test_maillists_lists_members_pages_get(self) -> None:
         req = self.client.lists_members_pages.get(
             domain=self.domain,
             address=self.maillist_address,
@@ -939,7 +939,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("items", req.json())
 
-    def test_maillists_lists_members_create(self):
+    def test_maillists_lists_members_create(self) -> None:
         self.client.lists_members.delete(
             domain=self.domain,
             address=self.maillist_address,
@@ -954,7 +954,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("member", req.json())
 
-    def test_maillists_lists_members_update(self):
+    def test_maillists_lists_members_update(self) -> None:
         self.client.lists_members.create(
             domain=self.domain,
             address=self.maillist_address,
@@ -971,7 +971,7 @@ class MailingListsTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("member", req.json())
 
-    def test_maillists_lists_members_delete(self):
+    def test_maillists_lists_members_delete(self) -> None:
         self.client.lists_members.create(
             domain=self.domain,
             address=self.maillist_address,
@@ -985,7 +985,7 @@ class MailingListsTest(unittest.TestCase):
         )
         self.assertEqual(req.status_code, 200)
 
-    def test_maillists_lists_members_create_mult(self):
+    def test_maillists_lists_members_create_mult(self) -> None:
         req = self.client.lists_members.create(
             domain=self.domain,
             address=self.maillist_address,
@@ -998,7 +998,7 @@ class MailingListsTest(unittest.TestCase):
 
 
 class TemplatesTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -1029,7 +1029,7 @@ class TemplatesTest(unittest.TestCase):
 
         self.put_template_version = "v11"
 
-    def test_create_template(self):
+    def test_create_template(self) -> None:
         self.client.templates.delete(
             domain=self.domain,
             template_name=self.post_template_data["name"],
@@ -1042,7 +1042,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_get_template(self):
+    def test_get_template(self) -> None:
         params = {"active": "yes"}
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
         req = self.client.templates.get(
@@ -1054,7 +1054,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_put_template(self):
+    def test_put_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
         req = self.client.templates.put(
             domain=self.domain,
@@ -1064,7 +1064,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_delete_template(self):
+    def test_delete_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
         req = self.client.templates.delete(
             domain=self.domain,
@@ -1073,7 +1073,7 @@ class TemplatesTest(unittest.TestCase):
 
         self.assertEqual(req.status_code, 200)
 
-    def test_post_version_template(self):
+    def test_post_version_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
 
         self.client.templates.delete(
@@ -1092,7 +1092,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_get_version_template(self):
+    def test_get_version_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
 
         self.client.templates.create(
@@ -1111,7 +1111,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_put_version_template(self):
+    def test_put_version_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
 
         self.client.templates.create(
@@ -1132,7 +1132,7 @@ class TemplatesTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("template", req.json())
 
-    def test_delete_version_template(self):
+    def test_delete_version_template(self) -> None:
         self.client.templates.create(data=self.post_template_data, domain=self.domain)
 
         self.post_template_version_data["tag"] = "v0"
@@ -1162,7 +1162,7 @@ class TemplatesTest(unittest.TestCase):
 
 
 class EmailValidationTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -1182,7 +1182,7 @@ class EmailValidationTest(unittest.TestCase):
         }
         self.post_address_validate = {"address": self.validation_address_1}
 
-    def test_post_address_validate(self):
+    def test_post_address_validate(self) -> None:
         req = self.client.addressvalidate.create(
             domain=self.domain,
             data=self.post_address_validate,
@@ -1192,7 +1192,7 @@ class EmailValidationTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_get_address_validate(self):
+    def test_get_address_validate(self) -> None:
         req = self.client.addressvalidate.get(
             domain=self.domain,
             filters=self.get_params_address_validate,
@@ -1201,7 +1201,7 @@ class EmailValidationTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("address", req.json())
 
-    def test_get_bulk_address_validate_status(self):
+    def test_get_bulk_address_validate_status(self) -> None:
         params = {"limit": 1}
         req = self.client.addressvalidate_bulk.get(domain=self.domain, filters=params)
         self.assertEqual(req.status_code, 200)
@@ -1209,7 +1209,7 @@ class EmailValidationTest(unittest.TestCase):
 
 
 class InboxPlacementTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.auth = (
             "api",
             os.environ["APIKEY"],
@@ -1224,7 +1224,7 @@ class InboxPlacementTest(unittest.TestCase):
             "html": "<html>HTML version of the body</html>",
         }
 
-    def test_post_inbox_tests(self):
+    def test_post_inbox_tests(self) -> None:
         req = self.client.inbox_tests.create(
             domain=self.domain,
             data=self.post_inbox_test,
@@ -1233,14 +1233,14 @@ class InboxPlacementTest(unittest.TestCase):
         self.assertEqual(req.status_code, 201)
         self.assertIn("tid", req.json())
 
-    def test_get_inbox_tests(self):
+    def test_get_inbox_tests(self) -> None:
         self.client.inbox_tests.create(domain=self.domain, data=self.post_inbox_test)
         req = self.client.inbox_tests.get(domain=self.domain)
 
         self.assertEqual(req.status_code, 200)
         self.assertIn("tests", req.json())
 
-    def test_get_simple_inbox_tests(self):
+    def test_get_simple_inbox_tests(self) -> None:
         test_id = self.client.inbox_tests.create(
             domain=self.domain,
             data=self.post_inbox_test,
@@ -1253,7 +1253,7 @@ class InboxPlacementTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertEqual(req.json()["tid"], test_id.json()["tid"])
 
-    def test_delete_inbox_tests(self):
+    def test_delete_inbox_tests(self) -> None:
         test_id = self.client.inbox_tests.create(
             domain=self.domain,
             data=self.post_inbox_test,
@@ -1266,7 +1266,7 @@ class InboxPlacementTest(unittest.TestCase):
 
         self.assertEqual(req.status_code, 200)
 
-    def test_get_counters_inbox_tests(self):
+    def test_get_counters_inbox_tests(self) -> None:
         test_id = self.client.inbox_tests.create(
             domain=self.domain,
             data=self.post_inbox_test,
@@ -1281,7 +1281,7 @@ class InboxPlacementTest(unittest.TestCase):
         self.assertEqual(req.status_code, 200)
         self.assertIn("counters", req.json())
 
-    def test_get_checks_inbox_tests(self):
+    def test_get_checks_inbox_tests(self) -> None:
         test_id = self.client.inbox_tests.create(
             domain=self.domain,
             data=self.post_inbox_test,

--- a/tests.py
+++ b/tests.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import os
 import unittest
+from typing import Any
 
 import pytest
 
@@ -8,13 +11,13 @@ from mailgun.client import Client
 
 class MessagesTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.data: dict[str, str] = {
             "from": os.environ["MESSAGES_FROM"],
             "to": os.environ["MESSAGES_TO"],
             # TODO: Check 'Domain $DOMAIN is not allowed to send: Free accounts are for test purposes only. Please upgrade or add the address to authorized recipients in Account Settings.'
@@ -42,51 +45,51 @@ class DomainTests(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.test_domain = "mailgun.wrapper.test2"
-        self.post_domain_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.test_domain: str = "mailgun.wrapper.test2"
+        self.post_domain_data: dict[str, str] = {
             "name": self.test_domain,
         }
-        self.post_domain_creds = {
+        self.post_domain_creds: dict[str, str] = {
             "login": f"alice_bob@{self.domain}",
             "password": "test_new_creds123",
         }
 
-        self.put_domain_creds = {
+        self.put_domain_creds: dict[str, str] = {
             "password": "test_new_creds",
         }
 
-        self.put_domain_connections_data = {
+        self.put_domain_connections_data: dict[str, str] = {
             "require_tls": "false",
             "skip_verification": "false",
         }
 
-        self.put_domain_tracking_data = {
+        self.put_domain_tracking_data: dict[str, str] = {
             "active": "yes",
             "skip_verification": "false",
         }
         # fmt: off
-        self.put_domain_unsubscribe_data = {
+        self.put_domain_unsubscribe_data: dict[str, str] = {
             "active": "yes",
             "html_footer": "\n<br>\n<p><a href=\"%unsubscribe_url%\">UnSuBsCrIbE</a></p>\n",
             "text_footer": "\n\nTo unsubscribe here click: <%unsubscribe_url%>\n\n",
         }
         # fmt: on
 
-        self.put_domain_dkim_authority_data = {
+        self.put_domain_dkim_authority_data: dict[str, str] = {
             "self": "false",
         }
 
-        self.put_domain_webprefix_data = {
+        self.put_domain_webprefix_data: dict[str, str] = {
             "web_prefix": "python",
         }
 
-        self.put_dkim_selector_data = {
+        self.put_dkim_selector_data: dict[str, str] = {
             "dkim_selector": "s",
         }
 
@@ -224,13 +227,13 @@ class DomainTests(unittest.TestCase):
 
 class IpTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.ip_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.ip_data: dict[str, str] = {
             "ip": os.environ["DOMAINS_DEDICATED_IP"],
         }
 
@@ -262,22 +265,22 @@ class IpTests(unittest.TestCase):
 
 class IpPoolsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.data: dict[str, str] = {
             "name": "test_pool",
             "description": "Test",
             "add_ip": os.environ["DOMAINS_DEDICATED_IP"],
         }
-        self.patch_data = {
+        self.patch_data: dict[str, str] = {
             "name": "test_pool1",
             "description": "Test1",
         }
-        self.ippool_id = ""
+        self.ippool_id: Any = ""
 
     def test_get_ippools(self) -> None:
         self.client.ippools.create(domain=self.domain, data=self.data)
@@ -321,13 +324,13 @@ class IpPoolsTests(unittest.TestCase):
 
 class EventsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.params = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.params: dict[str, str] = {
             "event": "rejected",
         }
 
@@ -345,13 +348,13 @@ class EventsTests(unittest.TestCase):
 
 class StatsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.params = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.params: dict[str, str | list[str]] = {
             "event": ["accepted"],
             "duration": "1m",
         }
@@ -364,22 +367,22 @@ class StatsTests(unittest.TestCase):
 
 class TagsTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.data: dict[str, str] = {
             "description": "Tests running",
         }
-        self.put_tags_data = {
+        self.put_tags_data: dict[str, str] = {
             "description": "Python testtt",
         }
-        self.stats_params = {
+        self.stats_params: dict[str, str] = {
             "event": "accepted",
         }
-        self.tag_name = "Python test"
+        self.tag_name: str = "Python test"
 
     def test_get_tags(self) -> None:
         req = self.client.tags.get(domain=self.domain)
@@ -430,19 +433,19 @@ class TagsTests(unittest.TestCase):
 
 class BouncesTests(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.bounces_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.bounces_data: dict[str, int | str] = {
             "address": "test30@gmail.com",
             "code": 550,
             "error": "Test error",
         }
 
-        self.bounces_json_data = [
+        self.bounces_json_data: list[dict[str, str]] = [
             {
                 "address": "test40@gmail.com",
                 "code": "550",
@@ -500,18 +503,18 @@ class BouncesTests(unittest.TestCase):
 
 class UnsubscribesTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.unsub_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.unsub_data: dict[str, str] = {
             "address": "test@gmail.com",
             "tag": "unsub_test_tag",
         }
 
-        self.unsub_json_data = [
+        self.unsub_json_data: list[dict[str, str | list[str]]] = [
             {
                 "address": "test1@gmail.com",
                 "tags": ["some tag"],
@@ -573,18 +576,18 @@ class UnsubscribesTest(unittest.TestCase):
 
 class ComplaintsTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.compl_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.compl_data: dict[str, str] = {
             "address": "test@gmail.com",
             "tag": "compl_test_tag",
         }
 
-        self.compl_json_data = [
+        self.compl_json_data: list[dict[str, str | list[str]]] = [
             {
                 "address": "test1@gmail.com",
                 "tags": ["some tag"],
@@ -647,18 +650,18 @@ class ComplaintsTest(unittest.TestCase):
 
 class WhiteListTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.whitel_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.whitel_data: dict[str, str] = {
             "address": "test@gmail.com",
             "tag": "whitel_test",
         }
 
-        self.whitl_json_data = [
+        self.whitl_json_data: list[dict[str, str]] = [
             {
                 "address": "test1@gmail.com",
                 "domain": self.domain,
@@ -698,23 +701,23 @@ class WhiteListTest(unittest.TestCase):
 
 class RoutesTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.routes_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.routes_data: dict[str, int | str | list[str]] = {
             "priority": 0,
             "description": "Sample route",
             "expression": f"match_recipient('.*@{self.domain}')",
             "action": ["forward('http://myhost.com/messages/')", "stop()"],
         }
-        self.routes_params = {
+        self.routes_params: dict[str, int] = {
             "skip": 1,
             "limit": 1,
         }
-        self.routes_put_data = {
+        self.routes_put_data: dict[str, int] = {
             "priority": 2,
         }
 
@@ -766,18 +769,18 @@ class RoutesTest(unittest.TestCase):
 
 class WebhooksTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.webhooks_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.webhooks_data: dict[str, str | list[str]] = {
             "id": "clicked",
             "url": ["https://i.ua"],
         }
 
-        self.webhooks_data_put = {
+        self.webhooks_data_put: dict[str, str] = {
             "url": "https://twitter.com",
         }
 
@@ -822,23 +825,23 @@ class WebhooksTest(unittest.TestCase):
 
 class MailingListsTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.maillist_address = os.environ["MAILLIST_ADDRESS"]
-        self.mailing_lists_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.maillist_address: str = os.environ["MAILLIST_ADDRESS"]
+        self.mailing_lists_data: dict[str, str] = {
             "address": f"python_sdk@{self.domain}",
             "description": "Mailgun developers list",
         }
 
-        self.mailing_lists_data_update = {
+        self.mailing_lists_data_update: dict[str, str] = {
             "description": "Mailgun developers list 121212",
         }
 
-        self.mailing_lists_members_data = {
+        self.mailing_lists_members_data: dict[str, bool | str] = {
             "subscribed": True,
             "address": "bar@example.com",
             "name": "Bob Bar",
@@ -846,7 +849,7 @@ class MailingListsTest(unittest.TestCase):
             "vars": '{"age": 26}',
         }
 
-        self.mailing_lists_members_put_data = {
+        self.mailing_lists_members_put_data: dict[str, bool | str] = {
             "subscribed": True,
             "address": "bar@example.com",
             "name": "Bob Bar",
@@ -854,7 +857,7 @@ class MailingListsTest(unittest.TestCase):
             "vars": '{"age": 28}',
         }
 
-        self.mailing_lists_members_data_mult = {
+        self.mailing_lists_members_data_mult: dict[str, bool | str] = {
             "upsert": True,
             "members": '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},'
             '{"name": "Bob", "address": "bob2@example.com", "vars": {"age": 34}}]',
@@ -999,13 +1002,13 @@ class MailingListsTest(unittest.TestCase):
 
 class TemplatesTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.post_template_data = {
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.post_template_data: dict[str, str] = {
             "name": "template.name20",
             "description": "template description",
             "template": "{{fname}} {{lname}}",
@@ -1013,21 +1016,23 @@ class TemplatesTest(unittest.TestCase):
             "comment": "version comment",
         }
 
-        self.put_template_data = {"description": "new template description"}
+        self.put_template_data: dict[str, str] = {
+            "description": "new template description",
+        }
 
-        self.post_template_version_data = {
+        self.post_template_version_data: dict[str, str] = {
             "tag": "v11",
             "template": "{{fname}} {{lname}}",
             "engine": "handlebars",
             "active": "no",
         }
-        self.put_template_version_data = {
+        self.put_template_version_data: dict[str, str] = {
             "template": "{{fname}} {{lname}}",
             "comment": "Updated version comment",
             "active": "no",
         }
 
-        self.put_template_version = "v11"
+        self.put_template_version: str = "v11"
 
     def test_create_template(self) -> None:
         self.client.templates.delete(
@@ -1163,24 +1168,26 @@ class TemplatesTest(unittest.TestCase):
 
 class EmailValidationTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
-        self.validation_address_1 = os.environ["VALIDATION_ADDRESS_1"]
-        self.validation_address_2 = os.environ["VALIDATION_ADDRESS_2"]
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
+        self.validation_address_1: str = os.environ["VALIDATION_ADDRESS_1"]
+        self.validation_address_2: str = os.environ["VALIDATION_ADDRESS_2"]
 
-        self.get_params_address_validate = {
+        self.get_params_address_validate: dict[str, str] = {
             "address": self.validation_address_1,
             "provider_lookup": "false",
         }
 
-        self.post_params_address_validate = {
+        self.post_params_address_validate: dict[str, str] = {
             "provider_lookup": "false",
         }
-        self.post_address_validate = {"address": self.validation_address_1}
+        self.post_address_validate: dict[str, str] = {
+            "address": self.validation_address_1,
+        }
 
     def test_post_address_validate(self) -> None:
         req = self.client.addressvalidate.create(
@@ -1210,14 +1217,14 @@ class EmailValidationTest(unittest.TestCase):
 
 class InboxPlacementTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.auth = (
+        self.auth: tuple[str, str] = (
             "api",
             os.environ["APIKEY"],
         )
-        self.client = Client(auth=self.auth)
-        self.domain = os.environ["DOMAIN"]
+        self.client: Client = Client(auth=self.auth)
+        self.domain: str = os.environ["DOMAIN"]
 
-        self.post_inbox_test = {
+        self.post_inbox_test: dict[str, str] = {
             "domain": "domain.com",
             "from": "user@sending_domain.com",
             "subject": "testSubject",

--- a/tests.py
+++ b/tests.py
@@ -17,7 +17,8 @@ class MessagesTests(unittest.TestCase):
         self.data = {
             "from": os.environ["MESSAGES_FROM"],
             "to": os.environ["MESSAGES_TO"],
-            "cc": os.environ["MESSAGES_CC"],
+            # TODO: Check 'Domain $DOMAIN is not allowed to send: Free accounts are for test purposes only. Please upgrade or add the address to authorized recipients in Account Settings.'
+            # "cc": os.environ["MESSAGES_CC"],
             "subject": "Hello Vasyl Bodaj",
             "text": "Congratulations!, you just sent an email with Mailgun! You are truly awesome!",
             "o:tag": "Python test",


### PR DESCRIPTION
## Links:

[Jira](https://mailgun.atlassian.net/browse/DE-1398) 

## Actions:

- PEP 484 enabled:
  - [x] Add type hints to `mailgun/client.py`
  - [x] Add type hints to `tests.py`
  - [x] Check that the file `py.typed` exists in the root folder
  - [x] Check `pyright` settings in `pyproject.toml` 
  - [x] Exclude the `mailgun/examples` folder from the `mypy` and `ruff` settings
  - [x] Check `mypy` configs in `pyproject.toml` 
  - [x] Add type ignores.
  - [x] Add `mypy` and `pyright` pre-commit hooks 
 
- Type hints checks locally by commands:
  - [x] `mypy mailgun/client.py --strict`
  - [x] `mypy mailgun/handlers/ --strict`
  - [x] `mypy mailgun/ --strict`
  - [x] `mypy tests.py --strict`
  - [x] `pyright .`
  - [x] `pytype .`

- Package management:
  - [x] Check that `mailgun = ["py.typed", "*.pyi"]` exists in `tool.setuptools.package-data`
  - [x] Update pre-commit hooks' versions if needed

- Other:
  - [x] Disable `MESSAGES_CC` in tests and add TODO