### PR TITLE
PEP 257 docstrings enabled

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,11 +118,11 @@ repos:
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.3
+    rev: v0.8.4
     hooks:
       # Run the linter.
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --preview, --exit-non-zero-on-fix]
       # Run the formatter.
       - id: ruff-format
 
@@ -133,7 +133,7 @@ repos:
           language_version: python3.12
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.13.0
+    rev: v1.14.0
     hooks:
     -   id: mypy
         args:
@@ -162,7 +162,7 @@ repos:
       - id: typos
 
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.19
+    rev: 0.7.21
     hooks:
       - id: mdformat
         additional_dependencies:

--- a/mailgun/__init__.py
+++ b/mailgun/__init__.py
@@ -1,0 +1,10 @@
+"""The `mailgun` package provides a Python SDK for interacting with the Mailgun API.
+
+Packages:
+    - examples: basic examples.
+    - handlers: predefined handlers.
+
+Modules:
+    - client: Defines the main API client.
+
+"""

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -229,6 +229,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: server response from API
+        :raises: TimeoutError, ApiError
         """
         url = self.build_url(url, domain=domain, method=method, **kwargs)
         req_method = getattr(requests, method)

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -179,7 +179,7 @@ class Endpoint:
         url: dict[str, Any],
         headers: dict[str, str],
         auth: tuple[str, str] | None,
-    ):
+    ) -> None:
         """Initialize a new Endpoint instance.
 
         :param url: URL dict with pairs {"base": "keys"}

--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -1,3 +1,15 @@
+"""This module provides the main client and helper classes for interacting with the Mailgun API.
+
+The `mailgun.client` module includes the core `Client` class for managing
+API requests, configuration, and error handling, as well as utility functions
+and classes for building request headers, URLs, and parsing responses.
+Classes:
+    - Config: Manages configuration settings for the Mailgun API.
+    - Endpoint: Represents specific API endpoints and provides methods for
+      common HTTP operations like GET, POST, PUT, and DELETE.
+    - Client: The main API client for authenticating and making requests.
+"""
+
 from __future__ import annotations
 
 import json

--- a/mailgun/handlers/__init__.py
+++ b/mailgun/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""This package provides predefined handlers for interacting with the Mailgun API."""

--- a/mailgun/handlers/default_handler.py
+++ b/mailgun/handlers/default_handler.py
@@ -29,6 +29,7 @@ def handle_default(
     :type _method: str
     :param kwargs: kwargs
     :return: final url for default endpoint
+    :raises: ApiError
     """
     if not domain:
         raise ApiError("Domain is missing!")

--- a/mailgun/handlers/domains_handler.py
+++ b/mailgun/handlers/domains_handler.py
@@ -48,6 +48,7 @@ def handle_domains(
     :type method: str
     :param kwargs: kwargs
     :return: final url for domain endpoint
+    :raises: ApiError
     """
     # TODO: Refactor this logic
     # fmt: off

--- a/mailgun/handlers/inbox_placement_handler.py
+++ b/mailgun/handlers/inbox_placement_handler.py
@@ -27,6 +27,7 @@ def handle_inbox(
     :type _method: str
     :param kwargs: kwargs
     :return: final url for inbox placement endpoint
+    :raises: ApiError
     """
     final_keys = path.join("/", *url["keys"]) if url["keys"] else ""
     if "test_id" in kwargs:

--- a/mailgun/handlers/templates_handler.py
+++ b/mailgun/handlers/templates_handler.py
@@ -27,6 +27,7 @@ def handle_templates(
     :type _method: str
     :param kwargs: kwargs
     :return: final url for Templates endpoint
+    :raises: ApiError
     """
     final_keys = path.join("/", *url["keys"]) if url["keys"] else ""
     if "template_name" in kwargs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ line-ending = "auto"
 #
 # This is currently disabled by default, but it is planned for this
 # to be opt-out in the future.
-docstring-code-format = false
+docstring-code-format = true
 
 # Set the line length limit used when formatting code snippets in
 # docstrings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ ignore = [
     # pycodestyle (E, W)
     "CPY001",   # Missing copyright notice at top of file
     "DOC201",  # DOC201 `return` is not documented in docstring
-    # TODO: Enable when the upstream issue is fixed, see https://github.com/astral-sh/ruff/issues/12520
+    # TODO: Enable DOC501 when the upstream issue is fixed, see https://github.com/astral-sh/ruff/issues/12520
     "DOC501",  # DOC501 Raised exception `ApiError` missing from docstring
     "E501",
     "PLR0913",  # PLR0913 Too many arguments in function definition (6 > 5)
@@ -274,6 +274,7 @@ max-complexity = 10
 ignore-overlong-task-comments = true
 
 [tool.ruff.lint.pydocstyle]
+# TODO: Enable the 'sphinx' style when it will be available, see https://github.com/astral-sh/ruff/pull/13286
 convention = "google"
 
 [tool.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,11 @@ ignore-overlong-task-comments = true
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.pydocstyle]
+convention = "google"
+match = ".*.py"
+match_dir = '^examples/'
+
 [tool.flake8]
 exclude = ["mailgun/examples/*"]
 # TODO: D100 - create docstrings for modules; D101 Missing docstring in public class; D102 Missing docstring in public method; D104 Missing docstring in public package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,9 @@ ignore = [
     "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None`
     # pycodestyle (E, W)
     "CPY001",   # Missing copyright notice at top of file
+    "DOC201",  # DOC201 `return` is not documented in docstring
+    # TODO: Enable when the upstream issue is fixed, see https://github.com/astral-sh/ruff/issues/12520
+    "DOC501",  # DOC501 Raised exception `ApiError` missing from docstring
     "E501",
     "PLR0913",  # PLR0913 Too many arguments in function definition (6 > 5)
 ]
@@ -244,14 +247,14 @@ line-ending = "auto"
 #
 # This is currently disabled by default, but it is planned for this
 # to be opt-out in the future.
-#docstring-code-format = false
+docstring-code-format = false
 
 # Set the line length limit used when formatting code snippets in
 # docstrings.
 #
 # This only has an effect when the `docstring-code-format` setting is
 # enabled.
-#docstring-code-line-length = "dynamic"
+docstring-code-line-length = "dynamic"
 
 # Ignore `E402` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,40 +195,21 @@ select = ["ALL"]
 
 external = ["DOC", "PLR"]
 
-exclude = ["mailgun/examples/*"]
+exclude = ["mailgun/examples/*", "tests.py"]
 
 #extend-select = ["W", "N", "UP", "B", "A", "C4", "PT", "SIM", "PD", "PLE", "RUF"]
 # Never enforce `E501` (line length violations).
 
 ignore = [
-    # TODO: Fix unused function argument: `debug`, `kwargs`, and `method` in class Client
-    "ARG001",  #  ARG001 Unused function argument: `debug`, `kwargs`, and `method` in class Client
-    # TODO: Fix A001 Variable `TimeoutError` is shadowing a Python builtin
-    "A001" ,
-    # TODO: Enable A, ANN, D, C901, TRY201, TRY003, EM101, PTH118, PLR0917 later
-    "A", "ANN", "D", "C901", "TRY201", "TRY003", "EM101", "PTH118", "PLR0912", "ERA001", "PLR0917", "TD002", "TD003", "FIX002",
+    # TODO: Enable C901, TRY201, TRY003, EM101, PTH118, PLR0917 later
+    "C901", "TRY201", "TRY003", "EM101", "PTH118", "PLR0912", "PLR0917", "TD002", "TD003", "FIX002",
     "ANN401",  # ANN401 Dynamically typed expressions (typing.Any) are disallowed in `**kwargs`
     "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None`
     # pycodestyle (E, W)
     "CPY001",   # Missing copyright notice at top of file
-    #"DOC501",  # DOC501 Raised exception `TimeoutError` and `ApiError` missing from docstring
-    # TODO: Fix D104 Missing docstring in public package
-    "D104",
     "E501",
-    "FBT001",  # Boolean-typed positional argument in function definition
-    "FBT002",  # Boolean default positional argument in function definition
-    # TODO: Replace with http.HTTPStatus, see https://docs.python.org/3/library/http.html#http-status-codes
-    "PLR2004",  # PLR2004 Magic value used in comparison, consider replacing `XXX` with a constant variable
     "PLR0913",  # PLR0913 Too many arguments in function definition (6 > 5)
-    #"PLR0917",  # PLR0917 Too many positional arguments
-    "Q003",   # Checks for avoidable escaped quotes ("\"" -> '"')
-    # TODO:" PT009 Use a regular `assert` instead of unittest-style `assertTrue`
-    "PT009",
-    "S311",  # S311 Standard pseudo-random generators are not suitable for cryptographic purposes
-    # TODO: T201 Replace `print` with logging functions
-    "T201",  # T201 `print` found
 ]
-
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -298,9 +279,8 @@ match = ".*.py"
 match_dir = '^examples/'
 
 [tool.flake8]
-exclude = ["mailgun/examples/*"]
-# TODO: D100 - create docstrings for modules; D101 Missing docstring in public class; D102 Missing docstring in public method; D104 Missing docstring in public package
-ignore = ['E501', "D100", "D101", "D102", "D104"]
+exclude = ["mailgun/examples/*", "tests.py"]
+ignore = ['E501']
 extend-ignore = "W503"
 per-file-ignores = [
     '__init__.py:F401',

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,5 @@
+"""A suite of tests for Mailgun Python SDK functionality."""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
Enable [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)

## Actions:

- [x] Add missing `docstrings` to:
  - [x] packages
  - [x] modules 
  - [x] verify all docstrings by running
    - [x] `ruff check . --preview`
    - [x] `flake8 .` 
    - [x] `pydocstyle .`
    - [x] `pre-commit run --all-files` 
  - [x] omit docstrings and linting in the `mailgun/examples` folder by keeping samples compact 
  - [x] exclude tests.py 

- [x] Additional fixes:
  - [x] Enable docstring lints
  - [x] Remove unused or fixed `ruff` lint rules

- [x] Other:
  - [x] Update `pre-commit` hooks 