### PR TITLE
Fix examples

### DIFF
--- a/mailgun/client.py
+++ b/mailgun/client.py
@@ -223,12 +223,13 @@ class Endpoint:
         :param timeout: requested timeout (60-default)
         :type timeout: int
         :param files: incoming files
-        :type files: dict[str, bytes] | None
+        :type files: dict[str, Any] | None
         :param domain: incoming domain
         :type domain: str | None
         :param kwargs: kwargs
         :type kwargs: Any
         :return: server response from API
+        :rtype: requests.models.Response
         :raises: TimeoutError, ApiError
         """
         url = self.build_url(url, domain=domain, method=method, **kwargs)
@@ -291,6 +292,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call GET request
+        :rtype: requests.models.Response
         """
         return self.api_call(
             self._auth,
@@ -322,10 +324,11 @@ class Endpoint:
         :param headers: incoming headers
         :type headers: str | None
         :param files: incoming files
-        :type files: dict[str, bytes] | None
+        :type files: dict[str, Any] | None
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call POST request
+        :rtype: requests.models.Response
         """
         if "Content-type" in self.headers:
             if self.headers["Content-type"] == "application/json":
@@ -364,6 +367,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call POST request
+        :rtype: requests.models.Response
         """
         return self.api_call(
             self._auth,
@@ -390,6 +394,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call PATCH request
+        :rtype: requests.models.Response
         """
         return self.api_call(
             self._auth,
@@ -416,6 +421,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call PUT request
+        :rtype: requests.models.Response
         """
         if self.headers["Content-type"] == "application/json":
             data = json.dumps(data)
@@ -437,6 +443,7 @@ class Endpoint:
         :param kwargs: kwargs
         :type kwargs: Any
         :return: api_call DELETE request
+        :rtype: requests.models.Response
         """
         return self.api_call(
             self._auth,

--- a/mailgun/examples/email_validation_examples.py
+++ b/mailgun/examples/email_validation_examples.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from mailgun.client import Client
 
@@ -45,8 +46,11 @@ def post_bulk_list_validate() -> None:
     POST /v4/address/validate/bulk/<list_id>
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"file": open("../doc_tests/files/email_validation.csv", "rb")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {"file": Path("mailgun/doc_tests/files/email_validation.csv").read_bytes()}
     req = client.addressvalidate_bulk.create(
         domain=domain, files=files, list_name="python2_list"
     )
@@ -85,8 +89,11 @@ def post_preview() -> None:
     POST /v4/address/validate/preview/<list_id>
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"file": open("../doc_tests/files/email_previews.csv", "rb")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {"file": Path("mailgun/doc_tests/files/email_previews.csv").read_bytes()}
     req = client.addressvalidate_preview.create(
         domain=domain, files=files, list_name="python_list"
     )

--- a/mailgun/examples/messages_examples.py
+++ b/mailgun/examples/messages_examples.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from mailgun.client import Client
 
@@ -28,16 +29,18 @@ def post_message() -> None:
         "html": html,
         "o:tag": "Python test",
     }
-    # "text": "Congratulations !!!!!, you just sent an email with Mailgun!  You are truly awesome!"}
-    # TODO: Refactor this by using with context manager or pathlib.Path
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
     files = [
         (
             "attachment",
-            ("test1.txt", open("../doc_tests/files/test1.txt", "rb").read()),
+            ("test1.txt", Path("mailgun/doc_tests/files/test1.txt").read_bytes()),
         ),
         (
             "attachment",
-            ("test2.txt", open("../doc_tests/files/test2.txt", "rb").read()),
+            ("test2.txt", Path("mailgun/doc_tests/files/test2.txt").read_bytes()),
         ),
     ]
 
@@ -54,8 +57,11 @@ def post_mime() -> None:
         "cc": os.environ["MESSAGES_CC"],
         "subject": "Hello HELLO",
     }
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"message": open("../doc_tests/files/test_mime.mime")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {"message": Path("mailgun/doc_tests/files/test_mime.mime").read_bytes()}
 
     req = client.mimemessage.create(data=mime_data, files=files, domain=domain)
     print(req.json())

--- a/mailgun/examples/suppressions_examples.py
+++ b/mailgun/examples/suppressions_examples.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from mailgun.client import Client
 
@@ -57,8 +58,15 @@ def import_bounce_list() -> None:
     POST /<domain>/bounces/import, Content-Type: multipart/form-data
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"bounce_csv": open("../doc_tests/files/mailgun_bounces_test.csv", "rb")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {
+        "bounce_csv": Path(
+            "mailgun/doc_tests/files/mailgun_bounces_test.csv"
+        ).read_bytes()
+    }
     req = client.bounces_import.create(domain=domain, files=files)
     print(req.json())
 
@@ -141,9 +149,14 @@ def import_list_unsubs() -> None:
     POST /<domain>/unsubscribes/import, Content-Type: multipart/form-data
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
     files = {
-        "unsubscribe2_csv": open("../doc_tests/files/mailgun_unsubscribes.csv", "rb")
+        "unsubscribe2_csv": Path(
+            "mailgun/doc_tests/files/mailgun_unsubscribes.csv"
+        ).read_bytes()
     }
     req = client.unsubscribes_import.create(domain=domain, files=files)
     print(req.json())
@@ -215,8 +228,15 @@ def import_complaint_list() -> None:
     POST /<domain>/complaints/import, Content-Type: multipart/form-data
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"complaints_csv": open("../doc_tests/files/mailgun_complaints.csv", "rb")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {
+        "complaints_csv": Path(
+            "mailgun/doc_tests/files/mailgun_complaints.csv"
+        ).read_bytes()
+    }
     req = client.complaints_import.create(domain=domain, files=files)
     print(req.json())
 
@@ -278,8 +298,15 @@ def import_list_whitelists() -> None:
     POST /<domain>/whitelists/import, Content-Type: multipart/form-data
     :return:
     """
-    # TODO: Refactor this by using with context manager or pathlib.Path
-    files = {"whitelist_csv": open("../doc_tests/files/mailgun_whitelists.csv", "rb")}
+    # It is strongly recommended that you open files in binary mode.
+    # Because the Content-Length header may be provided for you,
+    # and if it does this value will be set to the number of bytes in the file.
+    # Errors may occur if you open the file in text mode.
+    files = {
+        "whitelist_csv": Path(
+            "mailgun/doc_tests/files/mailgun_whitelists.csv"
+        ).read_bytes()
+    }
     req = client.whitelists_import.create(domain=domain, files=files)
     print(req.json())
 


### PR DESCRIPTION
### Actions:

Fixes:
- [x] Replace `open("...", "rb")` with `pathlib.Path("...").read_bytes()` and add comments about a strong recommendation to open files in binary mode. We do not perform write operations with files, so we must be confident that the file is closed after opening and reading in binary mode. Otherwise, there will be a lot of memory required to keep all the file handles open.

Docstrings:
- [x] Add `:rtype` with `requests.models.Response`
- [x] Fix `:type files` as `dict[str, Any] | None` because it can be a Dictionary of ``'name': file-like-objects`` (or ``{'name': file-tuple}``) for multipart encoding upload.``file-tuple`` can be a 2-tuple ``('filename', fileobj)``, 3-tuple ``('filename', fileobj, 'content_type')`` or a 4-tuple ``('filename', fileobj, 'content_type', custom_headers)``, where ``'content_type'`` is a string defining the content type of the given file and ``custom_headers`` a dict-like object containing additional headers to add for the file.